### PR TITLE
Version the release: __version__, dated CHANGELOG, release checklist (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
-### Initial public release
+## v0.1.0 (2026-08-06)
+
+First public release.
 
 - Local-first memory service: immutable episodic record with FTS,
   append-only fact ledger with temporal validity, and a continuously

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,24 @@ git config core.hooksPath .githooks
   synthetic by construction.
 - The scope boundaries in [ARCHITECTURE.md](ARCHITECTURE.md) are
   deliberate.
+
+## Releasing
+
+Versions are ordinary semantic versions in the 0.x range: no stability
+promise yet. `memory_service.__version__` is the single source, and the
+HTTP `contract_version` moves separately, only when the wire contract in
+[docs/API.md](docs/API.md) changes.
+
+Before a tag, every box:
+
+- [ ] Suite green keyless: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest -q`
+- [ ] `pip-audit -r requirements.txt --strict` clean
+- [ ] `bash scripts/secret-scan.sh --tree` green. The bare command scans
+      only staged lines, so at release time it would scan nothing and
+      still report clean; `--tree` is the one that looks.
+- [ ] No real personal data in code, tests, docs or fixtures
+- [ ] Screenshots and any demo database come from synthetic conversations
+      only, including the sidebar: generated titles summarise whatever a
+      chat actually discussed
+- [ ] `__version__` bumped, CHANGELOG entry dated, fresh `## Unreleased`
+      left above it

--- a/memory_service/__init__.py
+++ b/memory_service/__init__.py
@@ -1,0 +1,13 @@
+"""Membro: a local-first memory service for AI assistants.
+
+Two version numbers, deliberately independent:
+
+- `__version__` is the application's own release, moving with every
+  tagged release of this repository.
+- `Settings.contract_version` is the HTTP wire contract clients code
+  against (see docs/API.md). It moves only when that contract changes,
+  so a client is not asked to care about a release that did not touch
+  the surface it speaks to.
+"""
+
+__version__ = "0.1.0"

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -87,3 +87,16 @@ def test_ingest_is_idempotent(con, settings, sample_conversation):
     ])
     assert res == {"conversation_id": 1, "ingested": 1, "skipped": 1,
                    "attached": 0}
+
+
+def test_app_version_and_contract_version_are_independent():
+    """A release of the app must not silently move the wire contract that
+    clients code against, and vice versa. Keeping both here makes a change
+    to either one a deliberate edit rather than a side effect."""
+    import re
+
+    import memory_service
+    from memory_service.config import Settings
+
+    assert re.fullmatch(r"\d+\.\d+\.\d+", memory_service.__version__)
+    assert memory_service.__version__ != Settings().contract_version


### PR DESCRIPTION
Closes #12.

- `memory_service.__version__ = "0.1.0"`, with a module docstring stating why the app version and the HTTP `contract_version` are separate numbers: a release that does not touch the wire surface must not ask clients to care.
- CHANGELOG: the shipped entry is now `## v0.1.0 (2026-08-06)` with a fresh empty `## Unreleased` above it. Describing cloneable code as unreleased was simply untrue.
- CONTRIBUTING gains a release checklist, carried over from the private pre-flight doc: keyless tests, pip-audit, `--tree` scan (with the note that the bare command scans nothing at release time and still says clean), no real personal data, synthetic-only screenshots and demo databases.
- One test pins that the two version numbers stay independent, so moving either is a deliberate edit.

338 passed; tree scan green.

Tag `v0.1.0` and a GitHub release follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)