### PR TITLE
Three precision fixes on the open-route and trusted-hosts statements

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,8 +36,11 @@ Gated even on loopback: everything reading or writing exact rows
 (facts, review, verbatim search, attachments, jobs, consolidate).
 
 Open on loopback: `/v1/recall` (six fields, max 50 rows),
-`/v1/summary`, `/v1/health`, the ingest/distill/fact-create flows,
-`/v1/backup`, and every `/v1/viz/*` route.
+`/v1/summary` and its version list, `/v1/health`,
+`/v1/disposable-identity` (a probe for benchmark harnesses that
+answers "no" on a real install and reveals nothing else), the
+ingest/distill/fact-create flows, `/v1/backup`, and every `/v1/viz/*`
+route.
 
 Also open on loopback, and worth knowing before you assume otherwise:
 

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -133,7 +133,7 @@ of these constants is wrong, that's a bug report we want.
 | `mirror_keep` | `7` | Mirrored snapshots kept |
 | `host` / `port` | `127.0.0.1` / `8901` | Loopback-only by default, the security model (env: `MEMORY_PORT`) |
 | `auth_token` | unset | Your owner recovery secret and machine credential (env: `MEMORY_AUTH_TOKEN`) |
-| `trusted_hosts` | empty | Hostnames (your own tailnet name) where you may sign in with your owner password from a browser; the ledger stays sealed without a credential either way. Env only: `MEMORY_TRUSTED_HOSTS`, comma-separated. Read [SECURITY.md](../SECURITY.md) first |
+| `trusted_hosts` | empty | Hostnames (your own tailnet name) where you may sign in with your owner password from a browser; the ledger stays sealed without a credential either way. Config key `trusted_hosts` (a JSON list), or env `MEMORY_TRUSTED_HOSTS` (comma-separated). Read [SECURITY.md](../SECURITY.md) first |
 | `MEMORY_TAILSCALE_SERVE` | `0` (off) | Opt in to tailnet-only remote access at startup (env only, see below) |
 | `MEMORY_TAILSCALE_PORT` | `8443` | The HTTPS port Membro gets on your tailnet; its own origin rather than a path (env only) |
 | `MEMORY_TAILSCALE_BIN` | unset | Path to a `tailscale` CLI that is installed but not on `PATH`, the normal macOS case (env only) |
@@ -162,9 +162,9 @@ queue, every action on a single fact (edit, supersede, approve,
 dismiss, delete), the bulk quarantine and dismiss-all verbs, verbatim
 transcript search, the attachment routes, the consolidation sweep, and
 job results. It does **not** cover everything: recall, the profile,
-health, backup, the visualisation feeds, and the stored profile
-versions (including restoring one) all answer a local caller with no
-credential. [SECURITY.md](../SECURITY.md) says which, and why.
+health, backup, the visualisation feeds, the stored profile versions
+(including restoring one), and regenerating the live profile all
+answer a local caller with no credential. [SECURITY.md](../SECURITY.md) says which, and why.
 Two credentials satisfy the gate, and only one of them is for everyday
 use:
 


### PR DESCRIPTION
Closes #16.

Most of #16 turned out to be already fixed: the chmod and WAL/SHM wording it flagged was corrected by PR #15, which merged moments before the issue was filed. What remained, verified against the code today:

- **docs/TUNING.md** said the credential gate's exceptions were recall, the profile, health, backup, the viz feeds and the stored profile versions. It missed one: `POST /v1/summary/regenerate` also answers a local caller with no credential (it rebuilds the live profile, at LLM cost; the replaced profile is kept as a version). SECURITY.md already said this; the TUNING.md list now agrees.
- **SECURITY.md**'s open-on-loopback set omitted two open routes: `GET /v1/summary/versions` (the version list; metadata only) and `GET /v1/disposable-identity` (a probe for benchmark harnesses that answers "no" on a real install and reveals nothing else). Both are now named, so the list is the complete set.
- **docs/TUNING.md** said trusted hosts were "env only". Not so: a `trusted_hosts` key in config.json or config.local.json works too, because every config key merges into Settings, and the middleware lowercases values at comparison either way. The row now names both forms and their different shapes (JSON list vs comma-separated).

Docs only; no behaviour change. Full suite: 338 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)