### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+## v0.1.1 (2026-08-07)
+
+- SECURITY.md now names the complete set of routes open on loopback:
+  the profile version list, the disposable-identity probe, and profile
+  regeneration were missing from the stated lists.
+- TUNING.md documents that trusted hosts can be set by config key as
+  well as environment variable, and their different shapes (JSON list
+  vs comma-separated).
+- Docs state the credential gate once, in one place, and the import
+  command in the README is the one that works.
+
 ## v0.1.0 (2026-08-06)
 
 First public release.

--- a/memory_service/__init__.py
+++ b/memory_service/__init__.py
@@ -10,4 +10,4 @@ Two version numbers, deliberately independent:
   the surface it speaks to.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
Version bump and changelog roll-up for v0.1.1: the documentation-precision fixes from #15 and #17. The HTTP contract_version stays 1.1, unchanged and independent of the app version, as documented. Tag and GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)