### PR TITLE
Finish the rename in the six surfaces users still saw the old identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# multi-model-memory — environment keys. Copy to .env (git-ignored) and fill in.
+# Membro — environment keys. Copy to .env (git-ignored) and fill in.
 # Both keys are OPTIONAL but recommended; start.sh loads .env automatically and
 # prints exactly what degrades when a key is absent.
 

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -249,7 +249,7 @@ def _read_disposable_token(data_dir) -> str | None:
 def create_app(settings: Settings | None = None) -> FastAPI:
     settings = settings or load_settings()
     db.init(settings)
-    app = FastAPI(title="Membro (multi-model-memory)", version=settings.contract_version)
+    app = FastAPI(title="Membro", version=settings.contract_version)
     app.state.settings = settings
     app.state.backup_scheduler_stop = db.start_backup_scheduler(settings)
     app.router.on_shutdown.append(app.state.backup_scheduler_stop.set)

--- a/memory_service/mcp_admin_server.py
+++ b/memory_service/mcp_admin_server.py
@@ -120,7 +120,7 @@ def search_facts(query: str = "", status: str = "all") -> str:
     except RuntimeError as e:
         return f"Error: {e}"
     except httpx.HTTPError as e:
-        return f"Error reaching the memory service at {_base_url()}: {e}"
+        return f"Error reaching Membro at {_base_url()}: {e}"
     facts = r.json().get("facts", [])
     return _fmt(facts) if facts else "No matching facts."
 
@@ -143,7 +143,7 @@ def review_queue(query: str = "") -> str:
     except RuntimeError as e:
         return f"Error: {e}"
     except httpx.HTTPError as e:
-        return f"Error reaching the memory service at {_base_url()}: {e}"
+        return f"Error reaching Membro at {_base_url()}: {e}"
     facts = r.json().get("facts", [])
     if query.strip():
         q = query.strip().lower()

--- a/memory_service/mcp_server.py
+++ b/memory_service/mcp_server.py
@@ -25,7 +25,7 @@ from memory_service import recall as recall_mod, summary as summary_mod  # noqa:
 from memory_service import walls  # noqa: E402
 from memory_service.config import load_settings  # noqa: E402
 
-mcp = FastMCP("multi-model-memory")
+mcp = FastMCP("membro")
 SETTINGS = load_settings()
 CLIENT = os.environ.get("MEMORY_MCP_CLIENT", "claude-code")
 ORIGIN = f"mcp:{CLIENT}"  # access-log origin: these lookups happen in THIS

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -27,7 +27,7 @@
     --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
   }
-  /* Themes — same five palettes as multi-model-chat, mapped to admin tokens.
+  /* Themes — same five palettes as Crossband, mapped to admin tokens.
      Default (:root above) = Zinc. */
   [data-theme="midnight"] {
     --bg: #0b1120; --panel: #121a2b; --panel2: #1c2740; --border: #2a3a55;

--- a/memory_service/static/math.html
+++ b/memory_service/static/math.html
@@ -27,7 +27,7 @@
     --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
   }
-  /* Themes — same five palettes as multi-model-chat, mapped to admin tokens.
+  /* Themes — same five palettes as Crossband, mapped to admin tokens.
      Default (:root above) = Zinc. */
   [data-theme="midnight"] {
     --bg: #0b1120; --panel: #121a2b; --panel2: #1c2740; --border: #2a3a55;

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# start.sh — one-command boot for multi-model-memory.
+# start.sh — one-command boot for Membro.
 # Creates .venv if missing, installs deps only when requirements.txt changed,
 # refuses to start a second instance, warns loudly about missing API keys,
 # then runs the FastAPI service on http://127.0.0.1:8901.
@@ -79,5 +79,5 @@ if [ "${MEMORY_TAILSCALE_SERVE:-0}" = "1" ]; then
   bash scripts/tailscale-serve.sh || true
 fi
 
-echo "Starting multi-model-memory on http://127.0.0.1:$PORT (admin UI at /) ..."
+echo "Starting Membro on http://127.0.0.1:$PORT (admin UI at /) ..."
 exec .venv/bin/python -m memory_service.api

--- a/tests/test_mcp_admin_server.py
+++ b/tests/test_mcp_admin_server.py
@@ -89,4 +89,4 @@ def test_unreachable_service_degrades_to_a_clear_error(monkeypatch):
     monkeypatch.setenv("MEMORY_AUTH_TOKEN", "s3cret")
     monkeypatch.setenv("MEMORY_API_URL", "http://127.0.0.1:1/v1")  # nothing listens
     out = admin.search_facts("anything")
-    assert out.startswith("Error reaching the memory service")
+    assert out.startswith("Error reaching Membro")


### PR DESCRIPTION
Closes #19. Found by a rendered-UI plus source scan after the web UI itself checked out clean.

- start.sh banner: "Starting Membro" (was multi-model-memory)
- MCP server self-declares as `membro` (was multi-model-memory - this is what MCP clients list; the README's registration command already said membro). Metadata only: origin stamps are `mcp:<client>`, never the server name, so stored data and the trust gate are untouched.
- Swagger/OpenAPI title: "Membro" (was "Membro (multi-model-memory)")
- .env.example first line and two admin-tool error strings ("Error reaching Membro at ...")
- Two view-source-only CSS comments now name Crossband rather than multi-model-chat

The `source_app` wire values in docs and tests deliberately keep the historical multi-model-chat string. Suite: 338 passed (one assertion updated with the error string it pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)