### PR TITLE
The recalls watch view backfills on open

### DIFF
--- a/memory_service/access.py
+++ b/memory_service/access.py
@@ -60,6 +60,20 @@ def record(con, kind: str, query: str = "", origin: str = "http",
         log.exception("access-log write failed; the lookup itself succeeded")
 
 
+def tail(con, n: int = 15) -> list[dict]:
+    """The newest `n` events, oldest first — the live view's opening
+    backfill. Without it a freshly opened view shows nothing until a new
+    event happens, and quiet looks identical to broken (#22). Same fields
+    and the same privacy posture as events_since."""
+    try:
+        rows = con.execute(
+            "SELECT ts, kind, origin, substr(query, 1, 200) AS query "
+            "FROM access_log ORDER BY ts DESC LIMIT ?", (max(0, n),))
+        return [dict(r) for r in rows][::-1]
+    except sqlite3.OperationalError:  # table not created yet: no events
+        return []
+
+
 def events_since(con, ts: float, limit: int = 200) -> list[dict]:
     """Events newer than `ts`, oldest first — the /math live view's feed.
     Queries are the user's own questions (shown in that view by design);

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -1008,7 +1008,8 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
             c.close()
 
     @app.get("/v1/viz/recalls")
-    def viz_recalls(after: float = Query(0.0)):
+    def viz_recalls(after: float = Query(0.0),
+                    tail: int = Query(0, ge=0, le=100)):
         # Served from the persistent access log — survives restarts and
         # includes lookups made by MCP client processes, not just this one.
         # `query` is the user's own question verbatim (first 200 chars), so
@@ -1016,7 +1017,9 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         # unauthenticated loopback caller.
         c = con()
         try:
-            return {"events": access.events_since(c, after), "now": db.now()}
+            events = (access.tail(c, tail) if tail
+                      else access.events_since(c, after))
+            return {"events": events, "now": db.now()}
         finally:
             c.close()
 

--- a/memory_service/static/math.html
+++ b/memory_service/static/math.html
@@ -943,14 +943,23 @@ function initTrace() {
   async function pollLive() {
     if (document.visibilityState === "visible" && $("trace-follow").checked && !evoPlaying) {
       try {
-        const r = await fetch("/v1/viz/recalls?after=" + (liveTs ?? 9e12));
+        const r = await fetch(liveTs === null
+          ? "/v1/viz/recalls?tail=15" : "/v1/viz/recalls?after=" + liveTs);
         if (r.ok) {
           const d = await r.json();
           if (liveTs === null) {
-            liveTs = d.now; // first poll: just sync; act from the second on
-            if (!data) status.textContent =
+            liveTs = d.now; // first poll: sync the clock; act from the second on
+            // Backfill so quiet is visibly different from broken (#22): name
+            // the newest logged recall instead of opening onto a blank state.
+            const recent = d.events.filter(e => e.kind === "recall").pop();
+            const opening =
               "following live \u2014 every question pulses the summary; only deep " +
               "lookups reach the ledger and draw the trace";
+            if (!data) status.textContent = recent
+              ? opening + ". Last recall " +
+                new Date(recent.ts * 1000).toLocaleString() + ": \u201c" +
+                recent.query.slice(0, 60) + "\u201d"
+              : opening + ". Nothing logged yet on this store.";
           } else if (d.events.length) {
             liveTs = d.events[d.events.length - 1].ts;
             const flash = (id, delay) => setTimeout(() => {

--- a/tests/test_access_log.py
+++ b/tests/test_access_log.py
@@ -137,3 +137,14 @@ def test_query_capped_and_content_free(con):
     assert len(row["query"]) == access.QUERY_CAP
     # events carry ts/kind/origin/query only — never fact content or ids
     assert set(ev) == {"ts", "kind", "origin", "query"}
+
+
+def test_tail_returns_newest_events_oldest_first(settings):
+    """The live view's opening backfill: newest N, oldest first, so a fresh
+    view can show recent history instead of opening blank (#22)."""
+    with _client(settings) as client:
+        for q in ("first", "second", "third"):
+            client.post("/v1/recall", json={"query": q, "limit": 1})
+        out = client.get("/v1/viz/recalls?tail=2").json()["events"]
+        recalls = [e["query"] for e in out if e["kind"] == "recall"]
+        assert recalls == ["second", "third"]


### PR DESCRIPTION
Closes #22, found when the live view read as broken during a quiet period despite a healthy access log (8,813 rows, current to the minute).

- `/v1/viz/recalls?tail=N` returns the newest N events, oldest first (bounded at 100), with the same fields and the same privacy posture as the incremental feed.
- The /math live view's first poll uses `tail=15` and names the most recent recall in the status line ("Last recall <time>: 'query'"), so an opening user immediately sees the feature is alive; a genuinely empty store says so explicitly. Following live is unchanged from the second poll on.

Suite: 339 passed, including a new test pinning tail order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)