### PR TITLE
Passkey login: WebAuthn platform authenticator as the everyday unlock (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- Passkey login (#27): enrol a Touch ID / iCloud Keychain passkey from the
+  unlocked admin page (Admin → Passkeys) and the lock screen offers it first,
+  password one click behind it. The password and recovery secret are
+  unchanged. Passkeys are per web address — enrol `http://localhost:8901`
+  and each trusted host separately; `127.0.0.1` cannot hold one (a browser
+  rule: an IP address is not a valid WebAuthn relying party).
+
 ## v0.1.1 (2026-08-07)
 
 - SECURITY.md now names the complete set of routes open on loopback:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,12 +23,18 @@ serve your accumulated personal data, so:
 
 ## Credentials
 
-Two, with distinct jobs. The browser login is a durable password
-(scrypt verifier in the store). The admin bearer token gates first-run
-enrolment and password reset, and authenticates MCP/curl callers.
-Sessions are opaque server-side ids in httpOnly SameSite=Strict
-cookies; logout revokes an id everywhere; the token itself never rides
-in a cookie.
+Three, with distinct jobs. The everyday browser unlock is a passkey
+(WebAuthn platform authenticator) once one is enrolled; only the
+credential's public key is stored, so a copied store cannot impersonate
+it. The durable password (scrypt verifier in the store) is the fallback
+login. The admin bearer token gates first-run enrolment and password
+reset, and authenticates MCP/curl callers; passkey enrolment
+additionally requires an already-unlocked session, so it can never
+happen from the lock screen. Sessions are opaque server-side ids in
+httpOnly SameSite=Strict cookies; logout revokes an id everywhere; the
+token itself never rides in a cookie. A passkey is origin-bound: an
+assertion is accepted only for `localhost` or a host listed in
+`MEMORY_TRUSTED_HOSTS`, each enrolled separately.
 
 ## Open vs gated
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -175,6 +175,27 @@ longer accepted as the everyday login.
   same recovery-gated proof, allowed at any time, replacing the verifier.
 - `POST /logout` revokes the session server-side and clears the cookie.
 
+**Passkey login (#27).** With a passkey enrolled, the lock screen offers it
+first and the password moves one click behind it; a successful assertion
+mints exactly the same opaque session as a password login. The password and
+recovery secret are unchanged. A passkey is bound to the web origin it was
+created on, so `localhost` and each trusted host enrol separately, and an IP
+origin (`127.0.0.1`) can never hold one.
+
+- `POST /webauthn/register/options` and `POST /webauthn/register` (both
+  require an unlocked session or the bearer token): start and finish
+  enrolment for the origin the page is open on. Only the credential id and
+  public key are stored, beside the password verifier in the `settings`
+  table; the private key never leaves the authenticator.
+- `POST /webauthn/login/options` and `POST /webauthn/login` (lock-screen
+  surface): challenge out, signed assertion in, verified against the
+  enrolled public key with user verification (Touch ID / Face ID) required.
+  The options response discloses no credential ids — credentials are
+  enrolled as discoverable, so the browser finds its own.
+- `GET /webauthn/credentials` and `DELETE /webauthn/credentials/{id}`
+  (unlocked session or bearer): list and remove enrolled passkeys. Removal
+  can never lock the owner out; the password always remains.
+
 These endpoints are the browser admin UI surface (`include_in_schema=False`),
 not part of the versioned `/v1` contract, so `contract_version` is unchanged.
 

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -55,7 +55,17 @@ from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from pydantic import BaseModel, Field
 
-from . import access, auth, db, embeddings, episodic, jobs, ledger, mining, recall, summary, viz, walls
+import webauthn as webauthn_lib
+from webauthn.helpers import base64url_to_bytes, bytes_to_base64url
+from webauthn.helpers.exceptions import (InvalidAuthenticationResponse,
+                                         InvalidRegistrationResponse)
+from webauthn.helpers.structs import (AuthenticatorAttachment,
+                                      AuthenticatorSelectionCriteria,
+                                      PublicKeyCredentialDescriptor,
+                                      ResidentKeyRequirement,
+                                      UserVerificationRequirement)
+
+from . import access, auth, db, embeddings, episodic, jobs, ledger, mining, passkeys, recall, summary, viz, walls
 from .config import Settings, load_settings
 
 
@@ -122,6 +132,15 @@ class QuarantineBody(BaseModel):
     reason: str = Field(min_length=1)
 
 
+class WebAuthnFinishBody(BaseModel):
+    # The second half of either passkey ceremony (#27): the opaque ceremony id
+    # this server minted with the challenge, plus the browser's credential
+    # response verbatim. The dict is attacker-supplied by definition; nothing
+    # reads it except py_webauthn's verifier.
+    cid: str = Field(min_length=8, max_length=128)
+    credential: dict
+
+
 class RecallBody(BaseModel):
     query: str = ""
     # 50, not 500: recall is a retrieval aid, and an unbounded top-N over an
@@ -162,8 +181,13 @@ LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
 # else there needs the bearer token or a live admin session, so no anonymous
 # tailnet caller ever reaches fact data. `/enroll` and `/reset` still demand
 # the recovery secret in their own bodies — they are listed here because a
-# cookie cannot exist before they run, not because they are unguarded.
-LOGIN_SURFACE = {"/", "/login", "/logout", "/enroll", "/reset"}
+# cookie cannot exist before they run, not because they are unguarded. The two
+# passkey LOGIN steps (#27) belong here for the same reason: they are how a
+# session comes to exist, and the assertion they accept is signature-checked
+# against an enrolled credential. Passkey ENROLMENT is not here — it requires
+# an already-unlocked session, never the lock screen.
+LOGIN_SURFACE = {"/", "/login", "/logout", "/enroll", "/reset",
+                 "/webauthn/login/options", "/webauthn/login"}
 
 
 # Benchmark disposability sentinel (#90 slice 3). A THROWAWAY data dir that the
@@ -287,6 +311,52 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.state.admin_session_ttl = 60 * 60 * 24  # 24h — a deliberately bounded default
     ADMIN_SESSION_TTL = app.state.admin_session_ttl
 
+    # In-flight WebAuthn ceremonies (#27): ceremony id -> the challenge this
+    # server minted plus the origin/RP it was minted FOR. Server-side and
+    # single-use for the same reason sessions are: the browser echoes the
+    # challenge back inside a signed structure, and verification must compare
+    # it against a value the client never chose. In-memory on purpose — an
+    # abandoned ceremony should evaporate, and a restart mid-ceremony simply
+    # means clicking the button again.
+    app.state.webauthn_pending = {}
+    WEBAUTHN_CEREMONY_TTL = 300  # seconds; a Touch ID prompt answers in far less
+
+    def _webauthn_mint(purpose: str, challenge: bytes, rp_id: str, origin: str) -> str:
+        now = db.now()
+        for k, v in list(app.state.webauthn_pending.items()):
+            if v["expires"] < now:
+                app.state.webauthn_pending.pop(k, None)
+        cid = secrets.token_urlsafe(24)
+        app.state.webauthn_pending[cid] = {
+            "purpose": purpose, "challenge": challenge, "rp_id": rp_id,
+            "origin": origin, "expires": now + WEBAUTHN_CEREMONY_TTL,
+        }
+        return cid
+
+    def _webauthn_take(cid: str, purpose: str) -> dict | None:
+        """Pop a pending ceremony — single-use, so a captured response can
+        never be replayed against the same challenge. None for unknown,
+        expired, or wrong-purpose ids, all indistinguishable to the caller."""
+        pend = app.state.webauthn_pending.pop(cid or "", None)
+        if not pend or pend["purpose"] != purpose or pend["expires"] < db.now():
+            return None
+        return pend
+
+    def _webauthn_context(request: Request) -> tuple[str, str] | None:
+        """(origin, rp_id) for a ceremony on this request, or None where
+        passkeys cannot work. The RP comes from the request's own hostname
+        gated by the #83 trust boundary (loopback's `localhost` name, or a
+        host the operator listed in `trusted_hosts`); the origin is the
+        browser's Origin header, required to name that same host. 127.0.0.1
+        yields None: an IP is not a valid RP ID, so the lock screen there
+        stays password-first (#27, verified live)."""
+        host = request.url.hostname or ""
+        rp = passkeys.rp_for_host(host, settings.trusted_hosts)
+        origin = request.headers.get("origin", "")
+        if not rp or not passkeys.origin_ok(origin, host):
+            return None
+        return origin, rp
+
     # The trust boundary, enforced per-request (not just at bind time, so it
     # holds however the app is served). Two things at once:
     # 1. DNS-rebinding defense — a malicious page re-pointing its domain at
@@ -403,12 +473,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         finally:
             c.close()
 
-    def _locked_page(error: str = "", *, enrolled: bool | None = None) -> str:
+    def _locked_page(error: str = "", *, enrolled: bool | None = None,
+                     passkey: bool = False) -> str:
         # Deliberately minimal and dependency-free: no token, no verifier, no
         # ledger data, nothing but a form. Shown to any caller that hasn't
         # authenticated — including a sandboxed process making a bare GET / —
         # so there is NOTHING here for #46 v3's bypass to read. The recovery
-        # secret and the password verifier NEVER appear in this HTML (#51).
+        # secret and the password verifier NEVER appear in this HTML (#51),
+        # and neither does anything about a passkey beyond "one exists for
+        # this origin" (#27) — no credential id, no public key.
+        #
+        # `passkey` is set only on the plain GET / render when the CURRENT
+        # origin has an enrolled credential: the passkey button then leads and
+        # the password form waits behind a disclosure. Error re-renders from
+        # the password/reset forms keep the password layout: whoever just
+        # typed a wrong password wants the form, not a mode switch.
         if enrolled is None:
             enrolled = _enrolled()
         msg = f'<p class="err">{error}</p>' if error else ""
@@ -447,13 +526,68 @@ machine that can't see the terminal can't set your password.</small></p>"""
         else:
             # Ordinary case: log in with the enrolled password. A collapsible
             # reset path re-uses the same recovery-secret proof to set a new one.
-            body = f"""<p>Enter your password to unlock this browser.</p>
-{msg}
-<form method="post" action="/login">
+            # With a passkey enrolled for this origin, the passkey leads and
+            # this same password form waits behind a disclosure instead.
+            focus = "" if passkey else " autofocus"
+            password_form = f"""<form method="post" action="/login">
 <input type="text" name="username" value="owner" autocomplete="username" readonly aria-hidden="true" style="position:absolute;left:-9999px" tabindex="-1">
-<label>Password<input type="password" name="password" autocomplete="current-password" autofocus></label>
+<label>Password<input type="password" name="password" autocomplete="current-password"{focus}></label>
 <button type="submit">Unlock</button>
-</form>
+</form>"""
+            if passkey:
+                intro = f"""<button id="pk-btn" onclick="passkeyUnlock()" autofocus>Unlock with passkey</button>
+<p class="err" id="pk-err" role="alert"></p>
+{msg}
+<details id="pw-details"><summary>Use your password instead</summary>
+{password_form}
+</details>
+<script>
+"use strict";
+const b64uEnc = buf => btoa(String.fromCharCode(...new Uint8Array(buf)))
+  .replace(/\\+/g, "-").replace(/\\//g, "_").replace(/=+$/, "");
+const b64uDec = s => Uint8Array.from(
+  atob(s.replace(/-/g, "+").replace(/_/g, "/").padEnd(s.length + (4 - s.length % 4) % 4, "=")),
+  ch => ch.charCodeAt(0));
+async function passkeyUnlock() {{
+  const btn = document.getElementById("pk-btn"), err = document.getElementById("pk-err");
+  btn.disabled = true; err.textContent = "";
+  try {{
+    const or_ = await fetch("/webauthn/login/options", {{method: "POST"}});
+    const o = await or_.json();
+    if (!or_.ok) throw new Error((o.error && o.error.message) || "passkey unlock is not available here");
+    const pk = o.publicKey;
+    pk.challenge = b64uDec(pk.challenge);
+    (pk.allowCredentials || []).forEach(c => c.id = b64uDec(c.id));
+    const cred = await navigator.credentials.get({{publicKey: pk}});
+    const body = {{cid: o.cid, credential: {{
+      id: cred.id, rawId: b64uEnc(cred.rawId), type: cred.type,
+      clientExtensionResults: cred.getClientExtensionResults(),
+      response: {{
+        clientDataJSON: b64uEnc(cred.response.clientDataJSON),
+        authenticatorData: b64uEnc(cred.response.authenticatorData),
+        signature: b64uEnc(cred.response.signature),
+        userHandle: cred.response.userHandle ? b64uEnc(cred.response.userHandle) : null,
+      }},
+    }}}};
+    const rr = await fetch("/webauthn/login", {{method: "POST",
+      headers: {{"Content-Type": "application/json"}}, body: JSON.stringify(body)}});
+    const r = await rr.json();
+    if (!rr.ok || !r.ok) throw new Error((r.error && r.error.message) || "unlock failed");
+    location.replace("/");
+  }} catch (e) {{
+    err.textContent = e.name === "NotAllowedError"
+      ? "The passkey prompt was cancelled or timed out. Try again, or use your password."
+      : "Passkey unlock failed: " + e.message;
+    document.getElementById("pw-details").open = true;
+    btn.disabled = false;
+  }}
+}}
+</script>"""
+            else:
+                intro = f"""<p>Enter your password to unlock this browser.</p>
+{msg}
+{password_form}"""
+            body = intro + """
 <details><summary>Forgot your password?</summary>
 <p><small>Reset it with the <em>recovery secret</em> — the token printed to the
 terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
@@ -519,7 +653,20 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         # cookie automatically (same-origin, no JS needed) — nothing is
         # embedded in the page for a bare request to read.
         if not _admin_ok(request):
-            return HTMLResponse(_locked_page())
+            # Offer the passkey path only where it can work: the request's
+            # host maps to a valid RP (localhost or a trusted host, never an
+            # IP) AND a credential is enrolled for it (#27). The flag leaks
+            # nothing beyond "a passkey exists here" — the same granularity
+            # as the enrolled/first-run split this page already shows.
+            rp = passkeys.rp_for_host(request.url.hostname, settings.trusted_hosts)
+            has_passkey = False
+            if rp:
+                c = con()
+                try:
+                    has_passkey = bool(passkeys.credentials_for_rp(c, rp))
+                finally:
+                    c.close()
+            return HTMLResponse(_locked_page(passkey=has_passkey))
         return FileResponse(static_dir / "index.html", media_type="text/html")
 
     @app.post("/login", include_in_schema=False)
@@ -572,6 +719,195 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         resp = RedirectResponse("/", status_code=303)
         resp.delete_cookie(ADMIN_COOKIE, path="/")
         return resp
+
+    # ---- passkeys (#27): WebAuthn as the everyday unlock ----
+    # Enrolment lives behind an unlocked session (the admin page), never the
+    # lock screen; login is on LOGIN_SURFACE because it is how a session comes
+    # to exist. The password (#51) and recovery secret are untouched: a
+    # passkey replaces only the password PROOF, and mints the same opaque,
+    # expiring, revocable session as a password login.
+
+    @app.post("/webauthn/register/options", include_in_schema=False,
+              dependencies=[Depends(_admin_auth)])
+    def webauthn_register_options(request: Request):
+        # Start enrolment for the origin the admin page is open on. The
+        # challenge (and the origin/RP it was minted for) is held server-side;
+        # the browser gets back exactly what navigator.credentials.create
+        # needs, and nothing about any OTHER enrolled origin.
+        ctx = _webauthn_context(request)
+        if ctx is None:
+            raise HTTPException(400, "passkeys need http://localhost:"
+                                     f"{settings.port} or a trusted https host; "
+                                     "an IP address such as 127.0.0.1 cannot "
+                                     "hold one (browser rule, not ours)")
+        origin, rp = ctx
+        c = con()
+        try:
+            handle = passkeys.user_handle(c)
+            existing = passkeys.credentials_for_rp(c, rp)
+        finally:
+            c.close()
+        opts = webauthn_lib.generate_registration_options(
+            rp_id=rp, rp_name="membro", user_id=handle, user_name="owner",
+            user_display_name="Membro owner",
+            # Platform authenticator with a discoverable credential and true
+            # user verification: Touch ID / Face ID, resident on the device,
+            # so login can offer "use a passkey" without disclosing
+            # credential ids to the anonymous lock screen.
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                authenticator_attachment=AuthenticatorAttachment.PLATFORM,
+                resident_key=ResidentKeyRequirement.REQUIRED,
+                user_verification=UserVerificationRequirement.REQUIRED),
+            exclude_credentials=[
+                PublicKeyCredentialDescriptor(id=base64url_to_bytes(r["id"]))
+                for r in existing])
+        cid = _webauthn_mint("register", opts.challenge, rp, origin)
+        return {"cid": cid,
+                "publicKey": json.loads(webauthn_lib.options_to_json(opts))}
+
+    @app.post("/webauthn/register", include_in_schema=False,
+              dependencies=[Depends(_admin_auth)])
+    def webauthn_register(body: WebAuthnFinishBody):
+        # Finish enrolment: verify the browser's attestation response against
+        # the challenge/origin/RP recorded at options time, then persist ONLY
+        # the credential id and public key. py_webauthn owns the parsing of
+        # these attacker-suppliable bytes — that is the whole reason it is a
+        # dependency (#27).
+        pend = _webauthn_take(body.cid, "register")
+        if pend is None:
+            raise HTTPException(400, "enrolment challenge missing or expired; "
+                                     "start again from the Passkeys section")
+        try:
+            v = webauthn_lib.verify_registration_response(
+                credential=body.credential,
+                expected_challenge=pend["challenge"],
+                expected_rp_id=pend["rp_id"],
+                expected_origin=pend["origin"],
+                require_user_verification=True)
+        except (InvalidRegistrationResponse, ValueError):
+            raise HTTPException(400, "the browser's enrolment response did "
+                                     "not verify")
+        rec = {
+            "id": bytes_to_base64url(v.credential_id),
+            "public_key": bytes_to_base64url(v.credential_public_key),
+            "sign_count": v.sign_count,
+            "rp_id": pend["rp_id"],
+            "origin": pend["origin"],
+            "created_at": datetime.datetime.now(datetime.timezone.utc)
+                          .isoformat(timespec="seconds"),
+            "backed_up": bool(v.credential_backed_up),
+        }
+        c = con()
+        try:
+            # exclude_credentials steers the browser away from re-enrolling;
+            # this guards the API path itself.
+            if any(r.get("id") == rec["id"] for r in passkeys.list_credentials(c)):
+                raise HTTPException(409, "this passkey is already enrolled")
+            passkeys.add_credential(c, rec)
+        finally:
+            c.close()
+        return {"ok": True, "credential": {k: rec[k] for k in
+                                           ("id", "rp_id", "origin", "created_at")}}
+
+    @app.post("/webauthn/login/options", include_in_schema=False)
+    def webauthn_login_options(request: Request):
+        # Anonymous by design (lock screen), so it discloses as little as the
+        # page itself: a challenge and the RP, never a credential id or key —
+        # allowCredentials stays empty and the browser offers whatever
+        # DISCOVERABLE credential it holds for this RP (resident keys are
+        # required at enrolment for exactly this).
+        ctx = _webauthn_context(request)
+        if ctx is None:
+            raise HTTPException(400, "passkey unlock is not available on this "
+                                     "origin")
+        origin, rp = ctx
+        c = con()
+        try:
+            enrolled_here = bool(passkeys.credentials_for_rp(c, rp))
+        finally:
+            c.close()
+        if not enrolled_here:
+            raise HTTPException(400, "no passkey is enrolled for this origin")
+        opts = webauthn_lib.generate_authentication_options(
+            rp_id=rp,
+            user_verification=UserVerificationRequirement.REQUIRED)
+        cid = _webauthn_mint("login", opts.challenge, rp, origin)
+        return {"cid": cid,
+                "publicKey": json.loads(webauthn_lib.options_to_json(opts))}
+
+    @app.post("/webauthn/login", include_in_schema=False)
+    def webauthn_login(body: WebAuthnFinishBody):
+        # The passkey PROOF step. Errors are deliberately uniform 401s: an
+        # anonymous caller learns nothing about which part failed, matching
+        # the password path's single "incorrect" answer.
+        pend = _webauthn_take(body.cid, "login")
+        if pend is None:
+            raise HTTPException(401, "unlock challenge missing or expired; "
+                                     "try again")
+        cred_id = str(body.credential.get("rawId")
+                      or body.credential.get("id") or "")
+        c = con()
+        try:
+            rec = next((r for r in passkeys.credentials_for_rp(c, pend["rp_id"])
+                        if r.get("id") == cred_id), None)
+            if rec is None:
+                raise HTTPException(401, "passkey not recognised")
+            try:
+                v = webauthn_lib.verify_authentication_response(
+                    credential=body.credential,
+                    expected_challenge=pend["challenge"],
+                    expected_rp_id=pend["rp_id"],
+                    expected_origin=pend["origin"],
+                    credential_public_key=base64url_to_bytes(rec["public_key"]),
+                    credential_current_sign_count=int(rec.get("sign_count") or 0),
+                    require_user_verification=True)
+            except (InvalidAuthenticationResponse, ValueError):
+                raise HTTPException(401, "passkey not recognised")
+            # Persist the signature counter for clone detection next time
+            # (Apple authenticators report a constant 0; that verifies fine).
+            passkeys.update_sign_count(c, cred_id, v.new_sign_count)
+        finally:
+            c.close()
+        # Same session mint as a successful password login (#46 v4): fresh
+        # random opaque sid, never client-derived — but as JSON, because the
+        # caller is the lock page's fetch, which navigates on success itself.
+        sid = secrets.token_urlsafe(32)
+        app.state.admin_sessions[sid] = db.now() + ADMIN_SESSION_TTL
+        resp = JSONResponse({"ok": True})
+        resp.set_cookie(ADMIN_COOKIE, sid, httponly=True, samesite="strict",
+                        path="/", max_age=ADMIN_SESSION_TTL)
+        return resp
+
+    @app.get("/webauthn/credentials", include_in_schema=False,
+             dependencies=[Depends(_admin_auth)])
+    def webauthn_credentials():
+        # The Passkeys section's listing: metadata only, never the public key
+        # (nothing needs it client-side, so it does not travel).
+        c = con()
+        try:
+            rows = passkeys.list_credentials(c)
+        finally:
+            c.close()
+        return {"credentials": [
+            {k: r.get(k) for k in ("id", "rp_id", "origin", "created_at",
+                                   "backed_up")}
+            for r in rows]}
+
+    @app.delete("/webauthn/credentials/{cred_id}", include_in_schema=False,
+                dependencies=[Depends(_admin_auth)])
+    def webauthn_remove(cred_id: str):
+        # Removing a passkey is operational auth state, like a password reset
+        # (never ledger content). The device-side key remains; it simply
+        # stops unlocking this service. The password always remains as the
+        # fallback, so removal can never lock the owner out.
+        c = con()
+        try:
+            removed = passkeys.remove_credential(c, cred_id)
+        finally:
+            c.close()
+        if not removed:
+            raise HTTPException(404, "no passkey with that id")
+        return {"ok": True}
 
     @app.get("/math")
     def math_page():

--- a/memory_service/passkeys.py
+++ b/memory_service/passkeys.py
@@ -1,0 +1,162 @@
+"""Passkey (WebAuthn) credentials for the admin UI (#27).
+
+The everyday unlock becomes a passkey: Touch ID on this Mac, Face ID on a
+phone, whatever platform authenticator the browser offers. The password
+(auth.py) stays as the fallback and the recovery secret keeps its
+enrolment/reset role unchanged; a passkey replaces only the password proof
+step, never the session machinery.
+
+A passkey is bound to the exact web origin it was created on. `localhost` and
+a tailnet hostname share no domain suffix, so one credential cannot serve
+both; the store therefore keeps a LIST of credentials, each tagged with the
+Relying Party ID (the hostname) and full origin it belongs to, and the owner
+enrols each origin they actually use (#27, decided 2026-08-08). An IP address
+is not a valid Relying Party ID at all: browsing via 127.0.0.1 keeps the
+password-first lock screen, verified live before this was built.
+
+What lives here is storage and the origin/RP policy, never a ceremony: the
+challenge lifecycle and the cryptographic verification (py_webauthn) live in
+the HTTP layer, mirroring the auth.py split where the module holds the
+mechanism and the HTTP layer decides who may invoke it.
+
+Like the password verifier, credentials live in the durable `settings`
+key/value table (no schema change; an existing database simply has no
+passkeys yet). Only the PUBLIC key is ever stored: the private half lives in
+the platform authenticator (Secure Enclave / iCloud Keychain) and never
+reaches this process, so a copied store cannot impersonate the owner's
+passkey. Replacing or removing a credential is operational auth state, not
+ledger content, exactly like a password reset.
+"""
+
+import ipaddress
+import json
+import secrets
+
+from . import db
+
+# Durable settings keys. Absent = no passkey enrolled (fresh install, or one
+# that predates #27).
+CREDENTIALS_KEY = "webauthn_credentials"
+# One stable random user handle for the single owner, minted at first
+# enrolment. WebAuthn wants a user id that is NOT personal data; 16 random
+# bytes satisfy every authenticator and identify nothing.
+USER_HANDLE_KEY = "webauthn_user_handle"
+
+
+def rp_for_host(host: str | None, trusted_hosts) -> str | None:
+    """The WebAuthn Relying Party ID a request on `host` may use, or None if
+    passkeys cannot work there. Policy in one place:
+
+    - IP addresses (127.0.0.1, ::1, a bare tailnet IP) are never valid RP IDs;
+      the browser itself refuses them with SecurityError.
+    - `localhost` is always allowed: a secure context, a valid domain, and the
+      sanctioned loopback way to reach the UI in a browser.
+    - Any other hostname must be one the operator explicitly named in
+      `trusted_hosts` (the existing #83 trust boundary); the RP ID is then the
+      hostname itself, so the same credential works whatever port the tailnet
+      proxy publishes.
+    """
+    h = (host or "").strip().lower().rstrip(".")
+    if not h:
+        return None
+    try:
+        ipaddress.ip_address(h.strip("[]"))
+        return None
+    except ValueError:
+        pass
+    if h == "localhost":
+        return h
+    if h in {str(t).strip().lower() for t in trusted_hosts}:
+        return h
+    return None
+
+
+def origin_ok(origin: str | None, host: str | None) -> bool:
+    """True iff `origin` (an Origin request header) names this same host with
+    an acceptable scheme: https anywhere, plain http only for localhost. The
+    ceremony's expected origin is recorded from the page that started it and
+    later checked against the browser-signed clientDataJSON, so it must be an
+    origin we would trust serving the lock screen in the first place."""
+    from urllib.parse import urlsplit
+    try:
+        parts = urlsplit((origin or "").strip())
+        o_host = (parts.hostname or "").lower()
+    except ValueError:
+        return False
+    h = (host or "").strip().lower().rstrip(".")
+    if not o_host or o_host != h:
+        return False
+    if parts.scheme == "https":
+        return True
+    return parts.scheme == "http" and o_host == "localhost"
+
+
+# ---- durable storage (the settings key/value table) ----
+
+def list_credentials(con) -> list[dict]:
+    """Every enrolled passkey, oldest first. Any malformed stored value reads
+    as "none enrolled" rather than an exception: the lock screen must render
+    whatever state the store is in."""
+    raw = db.get_setting(con, CREDENTIALS_KEY, "")
+    if not raw:
+        return []
+    try:
+        rows = json.loads(raw)
+    except ValueError:
+        return []
+    return [r for r in rows if isinstance(r, dict)] if isinstance(rows, list) else []
+
+
+def credentials_for_rp(con, rp_id: str) -> list[dict]:
+    """The credentials usable on one Relying Party ID; drives both the lock
+    screen's "offer a passkey here?" decision and assertion lookup."""
+    return [r for r in list_credentials(con) if r.get("rp_id") == rp_id]
+
+
+def add_credential(con, rec: dict) -> None:
+    rows = list_credentials(con)
+    rows.append(rec)
+    db.set_setting(con, CREDENTIALS_KEY, json.dumps(rows))
+    con.commit()
+
+
+def remove_credential(con, cred_id: str) -> bool:
+    """Drop one credential by its (base64url) id. True if something was
+    removed. The private key on the device is untouched; the credential
+    simply stops unlocking this service."""
+    rows = list_credentials(con)
+    kept = [r for r in rows if r.get("id") != cred_id]
+    if len(kept) == len(rows):
+        return False
+    db.set_setting(con, CREDENTIALS_KEY, json.dumps(kept))
+    con.commit()
+    return True
+
+
+def update_sign_count(con, cred_id: str, sign_count: int) -> None:
+    """Persist the authenticator's post-assertion signature counter so a
+    cloned-credential replay (counter going backwards) is detectable next
+    time. Apple platform authenticators report a constant 0; storing it is
+    still correct and costs nothing."""
+    rows = list_credentials(con)
+    for r in rows:
+        if r.get("id") == cred_id:
+            r["sign_count"] = int(sign_count)
+    db.set_setting(con, CREDENTIALS_KEY, json.dumps(rows))
+    con.commit()
+
+
+def user_handle(con) -> bytes:
+    """The stable random WebAuthn user handle for the single owner, minted on
+    first use and persisted so every credential, on every origin, belongs to
+    the same user entry in the authenticator's eyes."""
+    stored = db.get_setting(con, USER_HANDLE_KEY, "")
+    if stored:
+        try:
+            return bytes.fromhex(stored)
+        except ValueError:
+            pass
+    handle = secrets.token_bytes(16)
+    db.set_setting(con, USER_HANDLE_KEY, handle.hex())
+    con.commit()
+    return handle

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -563,6 +563,29 @@
     <h2 class="group-head">Admin
       <span class="why">Rare &amp; dangerous: diagnostics and permanent deletes — usually leave alone</span></h2>
     <details class="section">
+      <summary>Passkeys
+        <span class="badge" id="pk-count"></span>
+        <span style="flex:1"></span>
+        <button onclick="event.preventDefault();loadPasskeys()">Refresh</button></summary>
+      <div class="body">
+        <details class="help"><summary>What is this &amp; why it matters</summary><p><b>Unlock with your fingerprint instead of typing your password.</b> A passkey lets
+          this browser unlock Membro with Touch ID (or Face ID on a phone) — quicker than the
+          password, and nothing to remember or leak. Your password keeps working as the fallback,
+          and the recovery secret still handles resets, so a passkey can never lock you out. One
+          catch, by browser design: a passkey is tied to the exact web address it was made on, so
+          enrol one here <em>and</em> another wherever else you open Membro (say, over your
+          tailnet). The address <code>127.0.0.1</code> can't hold one at all — use
+          <code>localhost</code>. Removing a passkey below stops it unlocking Membro; the copy on
+          your device can then be tidied away in your device's password settings.</p></details>
+        <div class="fields">
+          <button onclick="enrolPasskey()" id="pk-enrol">Enrol a passkey in this browser</button>
+          <span class="count-line" id="pk-msg" role="status"></span>
+        </div>
+        <div id="passkeys-body"><div class="empty">Loading…</div></div>
+      </div>
+    </details>
+
+    <details class="section">
       <summary>Database health
         <span style="flex:1"></span><button onclick="event.preventDefault();loadHealth()">Refresh</button></summary>
       <div class="body">
@@ -1354,9 +1377,90 @@ async function loadHealth() {
     `<dl class="health">${healthRows(h.detail || {}).join("")}</dl>`;
 }
 
+// ---- passkeys (#27) ----
+// Not under /v1 (they are browser-session plumbing, not contract surface),
+// so these use plain fetch rather than api(). Same-origin cookies ride along
+// automatically.
+
+const pkB64uEnc = buf => btoa(String.fromCharCode(...new Uint8Array(buf)))
+  .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+const pkB64uDec = s => Uint8Array.from(
+  atob(s.replace(/-/g, "+").replace(/_/g, "/").padEnd(s.length + (4 - s.length % 4) % 4, "=")),
+  ch => ch.charCodeAt(0));
+
+async function loadPasskeys() {
+  try {
+    const r = await fetch("/webauthn/credentials");
+    if (!r.ok) throw new Error("HTTP " + r.status);
+    const rows = (await r.json()).credentials || [];
+    $("pk-count").textContent = String(rows.length);
+    $("passkeys-body").innerHTML = rows.length
+      ? `<div class="table-wrap"><table><thead><tr>
+           <th>Where it works</th><th>Enrolled</th><th>Synced</th><th></th>
+         </tr></thead><tbody>` + rows.map(c => `<tr>
+           <td class="mono">${esc(c.origin)}</td>
+           <td class="mono">${esc((c.created_at || "").slice(0, 10))}</td>
+           <td>${c.backed_up ? "yes (e.g. iCloud)" : "this device only"}</td>
+           <td><button class="bad" onclick="removePasskey('${esc(c.id)}')">Remove</button></td>
+         </tr>`).join("") + "</tbody></table></div>"
+      : `<div class="empty">No passkeys yet — enrol one to unlock with Touch ID instead of your password.</div>`;
+  } catch (e) {
+    $("passkeys-body").innerHTML = `<div class="empty">Couldn't load passkeys: ${esc(e.message)}</div>`;
+  }
+}
+
+async function enrolPasskey() {
+  const btn = $("pk-enrol"), msg = $("pk-msg");
+  btn.disabled = true; msg.textContent = "";
+  try {
+    if (!window.PublicKeyCredential) throw new Error("this browser has no passkey support");
+    const or_ = await fetch("/webauthn/register/options", { method: "POST" });
+    const o = await or_.json();
+    if (!or_.ok) throw new Error((o.error && o.error.message) || "HTTP " + or_.status);
+    const pk = o.publicKey;
+    pk.challenge = pkB64uDec(pk.challenge);
+    pk.user.id = pkB64uDec(pk.user.id);
+    (pk.excludeCredentials || []).forEach(c => c.id = pkB64uDec(c.id));
+    const cred = await navigator.credentials.create({ publicKey: pk });
+    const body = { cid: o.cid, credential: {
+      id: cred.id, rawId: pkB64uEnc(cred.rawId), type: cred.type,
+      clientExtensionResults: cred.getClientExtensionResults(),
+      response: {
+        clientDataJSON: pkB64uEnc(cred.response.clientDataJSON),
+        attestationObject: pkB64uEnc(cred.response.attestationObject),
+        transports: cred.response.getTransports ? cred.response.getTransports() : [],
+      },
+    }};
+    const rr = await fetch("/webauthn/register", { method: "POST",
+      headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+    const r = await rr.json();
+    if (!rr.ok || !r.ok) throw new Error((r.error && r.error.message) || "enrolment did not verify");
+    toast("Passkey enrolled — the lock screen here now offers it first.", true);
+    loadPasskeys();
+  } catch (e) {
+    msg.textContent = e.name === "NotAllowedError"
+      ? "Cancelled or timed out — nothing was enrolled."
+      : e.name === "InvalidStateError"
+        ? "This device already has a passkey for this address."
+        : "Enrolment failed: " + e.message;
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function removePasskey(id) {
+  if (!confirm("Remove this passkey? It will stop unlocking Membro; your password still works.")) return;
+  try {
+    const r = await fetch("/webauthn/credentials/" + encodeURIComponent(id), { method: "DELETE" });
+    if (!r.ok) throw new Error("HTTP " + r.status);
+    toast("Passkey removed.", true);
+    loadPasskeys();
+  } catch (e) { toast("Couldn't remove passkey: " + e.message); }
+}
+
 // ---- boot ----
 
-loadReview(); loadSummary(); loadLedger(); loadFiles(); loadHealth();
+loadReview(); loadSummary(); loadLedger(); loadFiles(); loadHealth(); loadPasskeys();
 setInterval(() => { if (document.visibilityState === "visible") loadHealth(); }, 15000);
 </script>
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,8 @@ mcp>=1.0,<2
 pytest>=8.0
 httpx>=0.27
 pypdf
+# Passkey (WebAuthn) verification for the admin UI (#27): vetted parsing and
+# verification of authenticator responses; pulls in cryptography + cbor2.
+# Capped at <3 like mcp above: verification semantics are security-load-bearing,
+# so a major bump is its own reviewed change.
+webauthn>=2.2,<3

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -1,0 +1,396 @@
+"""Passkey (WebAuthn) login — #27.
+
+The everyday unlock becomes a platform-authenticator passkey; the password
+stays as the fallback and the recovery secret keeps its enrolment/reset role.
+The acceptance surface here:
+
+- Enrolment is possible ONLY from an already-authenticated caller (session or
+  bearer), never the lock screen — the sandboxed-agent rule from #51 again.
+- A passkey is bound to the origin it was enrolled on: `localhost` and a
+  trusted tailnet host enrol separately, an IP origin can hold nothing, and an
+  assertion signed for one origin is refused on another.
+- A successful assertion mints the SAME kind of opaque, expiring, revocable
+  session as a password login; a failed or replayed one mints nothing.
+- Credentials persist across a restart (durable settings table); in-flight
+  ceremonies and sessions do not (in-memory by design).
+
+Tests run keyless and offline: the "authenticator" is a tiny software P-256
+passkey built on py_webauthn's own dependencies (cryptography, cbor2), signing
+exactly the byte layouts a real platform authenticator produces.
+"""
+
+import hashlib
+import json
+
+import cbor2
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi.testclient import TestClient
+from webauthn.helpers import base64url_to_bytes, bytes_to_base64url
+
+from memory_service import auth, db, passkeys
+from memory_service.api import create_app
+from memory_service.config import Settings
+
+PASSWORD = "a-durable-owner-passphrase"
+LOCAL_ORIGIN = "http://localhost"
+TAILNET_HOST = "cat.tailtest.ts.net"
+TAILNET_ORIGIN = f"https://{TAILNET_HOST}:8443"
+
+
+# ── a minimal software platform authenticator ───────────────────────────────
+
+class SoftPasskey:
+    """A P-256 passkey that behaves like a platform authenticator for one RP:
+    same byte layouts, same signatures, no hardware. `sign_count` stays 0 by
+    default, exactly like Apple's authenticators, unless a test drives it."""
+
+    def __init__(self, rp_id="localhost"):
+        self.rp_id = rp_id
+        self.key = ec.generate_private_key(ec.SECP256R1())
+        import secrets as _s
+        self.cred_id = _s.token_bytes(16)
+
+    def _cose_key(self) -> bytes:
+        nums = self.key.public_key().public_numbers()
+        return cbor2.dumps({1: 2, 3: -7, -1: 1,
+                            -2: nums.x.to_bytes(32, "big"),
+                            -3: nums.y.to_bytes(32, "big")})
+
+    @staticmethod
+    def _client_data(kind: str, challenge_b64u: str, origin: str) -> bytes:
+        return json.dumps({"type": kind, "challenge": challenge_b64u,
+                           "origin": origin, "crossOrigin": False}).encode()
+
+    def register(self, public_key_options: dict, origin: str) -> dict:
+        cdj = self._client_data("webauthn.create",
+                                public_key_options["challenge"], origin)
+        flags = 0x01 | 0x04 | 0x40  # UP | UV | AT (attested credential data)
+        auth_data = (hashlib.sha256(self.rp_id.encode()).digest()
+                     + bytes([flags]) + (0).to_bytes(4, "big")
+                     + bytes(16)  # zero AAGUID, like fmt "none"
+                     + len(self.cred_id).to_bytes(2, "big")
+                     + self.cred_id + self._cose_key())
+        att = cbor2.dumps({"fmt": "none", "attStmt": {}, "authData": auth_data})
+        return {"id": bytes_to_base64url(self.cred_id),
+                "rawId": bytes_to_base64url(self.cred_id),
+                "type": "public-key", "clientExtensionResults": {},
+                "response": {"clientDataJSON": bytes_to_base64url(cdj),
+                             "attestationObject": bytes_to_base64url(att)}}
+
+    def assertion(self, public_key_options: dict, origin: str, *,
+                  sign_count: int = 0) -> dict:
+        cdj = self._client_data("webauthn.get",
+                                public_key_options["challenge"], origin)
+        flags = 0x01 | 0x04  # UP | UV
+        auth_data = (hashlib.sha256(self.rp_id.encode()).digest()
+                     + bytes([flags]) + sign_count.to_bytes(4, "big"))
+        sig = self.key.sign(auth_data + hashlib.sha256(cdj).digest(),
+                            ec.ECDSA(hashes.SHA256()))
+        return {"id": bytes_to_base64url(self.cred_id),
+                "rawId": bytes_to_base64url(self.cred_id),
+                "type": "public-key", "clientExtensionResults": {},
+                "response": {"clientDataJSON": bytes_to_base64url(cdj),
+                             "authenticatorData": bytes_to_base64url(auth_data),
+                             "signature": bytes_to_base64url(sig),
+                             "userHandle": None}}
+
+
+# ── plumbing ────────────────────────────────────────────────────────────────
+
+def _app(tmp_path, **kw):
+    return create_app(Settings(data_dir=tmp_path / "data", **kw))
+
+
+def _client(app, base_url=LOCAL_ORIGIN, token=None):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    return TestClient(app, base_url=base_url, headers=headers)
+
+
+def _owner(app, base_url=LOCAL_ORIGIN):
+    """A client holding the bearer token — the enrolled-and-unlocked owner."""
+    return _client(app, base_url=base_url, token=app.state.admin_token)
+
+
+def _enrol_passkey(client, origin=LOCAL_ORIGIN, rp="localhost", pk=None):
+    pk = pk or SoftPasskey(rp)
+    o = client.post("/webauthn/register/options", headers={"Origin": origin})
+    assert o.status_code == 200, o.text
+    body = {"cid": o.json()["cid"],
+            "credential": pk.register(o.json()["publicKey"], origin)}
+    r = client.post("/webauthn/register", json=body, headers={"Origin": origin})
+    return pk, r
+
+
+def _passkey_login(client, pk, origin=LOCAL_ORIGIN, *, sign_count=0,
+                   mangle=None):
+    o = client.post("/webauthn/login/options", headers={"Origin": origin})
+    if o.status_code != 200:
+        return o
+    cred = pk.assertion(o.json()["publicKey"],
+                        origin if mangle is None else mangle,
+                        sign_count=sign_count)
+    return client.post("/webauthn/login",
+                       json={"cid": o.json()["cid"], "credential": cred},
+                       headers={"Origin": origin})
+
+
+# ── policy: where a passkey may exist at all ────────────────────────────────
+
+def test_rp_for_host_policy():
+    assert passkeys.rp_for_host("localhost", []) == "localhost"
+    assert passkeys.rp_for_host("LOCALHOST", []) == "localhost"
+    assert passkeys.rp_for_host("127.0.0.1", []) is None        # IPs never
+    assert passkeys.rp_for_host("::1", []) is None
+    assert passkeys.rp_for_host(TAILNET_HOST, []) is None       # not trusted
+    assert passkeys.rp_for_host(TAILNET_HOST, [TAILNET_HOST]) == TAILNET_HOST
+    assert passkeys.rp_for_host("100.101.102.103",
+                                ["100.101.102.103"]) is None    # trusted ≠ valid
+    assert passkeys.rp_for_host(None, []) is None
+
+
+def test_origin_policy_https_anywhere_http_only_for_localhost():
+    assert passkeys.origin_ok("http://localhost", "localhost")
+    assert passkeys.origin_ok("http://localhost:8901", "localhost")
+    assert passkeys.origin_ok(TAILNET_ORIGIN, TAILNET_HOST)
+    assert not passkeys.origin_ok(f"http://{TAILNET_HOST}", TAILNET_HOST)
+    assert not passkeys.origin_ok("http://localhost", TAILNET_HOST)  # mismatch
+    assert not passkeys.origin_ok("https://evil.example", "localhost")
+    assert not passkeys.origin_ok("", "localhost")
+
+
+def test_register_options_refused_on_ip_origin(tmp_path):
+    app = _app(tmp_path)
+    c = _owner(app, base_url="http://127.0.0.1")
+    r = c.post("/webauthn/register/options",
+               headers={"Origin": "http://127.0.0.1"})
+    assert r.status_code == 400
+    assert "localhost" in r.json()["error"]["message"]
+
+
+# ── enrolment is never anonymous ────────────────────────────────────────────
+
+def test_enrolment_requires_an_authenticated_caller(tmp_path):
+    app = _app(tmp_path)
+    c = _client(app)  # no session, no bearer
+    assert c.post("/webauthn/register/options",
+                  headers={"Origin": LOCAL_ORIGIN}).status_code == 401
+    assert c.post("/webauthn/register", json={"cid": "x" * 24, "credential": {}},
+                  headers={"Origin": LOCAL_ORIGIN}).status_code == 401
+    assert c.get("/webauthn/credentials").status_code == 401
+    assert c.delete("/webauthn/credentials/anything").status_code == 401
+
+
+# ── the round trip ──────────────────────────────────────────────────────────
+
+def test_enrol_then_unlock_with_passkey(tmp_path):
+    app = _app(tmp_path)
+    pk, r = _enrol_passkey(_owner(app))
+    assert r.status_code == 200 and r.json()["ok"]
+
+    visitor = _client(app)  # a fresh, anonymous browser
+    assert visitor.get("/v1/facts").status_code == 401
+    login = _passkey_login(visitor, pk)
+    assert login.status_code == 200 and login.json()["ok"]
+    assert visitor.cookies.get("mm_admin")
+    assert visitor.get("/v1/facts").status_code == 200
+
+
+def test_lock_screen_offers_passkey_only_where_one_exists(tmp_path):
+    app = _app(tmp_path)
+    # password enrolled so the ordinary login layout renders
+    _client(app).post("/enroll", data={"recovery": app.state.admin_token,
+                                       "password": PASSWORD,
+                                       "confirm": PASSWORD})
+    before = _client(app).get("/").text
+    assert "Unlock with passkey" not in before
+
+    _enrol_passkey(_owner(app))
+    on_localhost = _client(app).get("/").text
+    assert "Unlock with passkey" in on_localhost
+    assert "Use your password instead" in on_localhost
+    # the same install browsed via the IP stays password-first, quietly
+    on_ip = _client(app, base_url="http://127.0.0.1").get("/").text
+    assert "Unlock with passkey" not in on_ip
+    assert 'name="password"' in on_ip
+
+
+def test_lock_screen_and_options_leak_no_credential_material(tmp_path):
+    app = _app(tmp_path)
+    pk, _ = _enrol_passkey(_owner(app))
+    anon = _client(app)
+    page = anon.get("/").text
+    options = anon.post("/webauthn/login/options",
+                        headers={"Origin": LOCAL_ORIGIN}).json()
+    cred_id = bytes_to_base64url(pk.cred_id)
+    for surface in (page, json.dumps(options)):
+        assert cred_id not in surface
+        assert "public_key" not in surface
+    # discoverable credentials: no allowCredentials disclosed at all
+    assert not options["publicKey"].get("allowCredentials")
+
+
+def test_password_fallback_still_works_with_passkey_enrolled(tmp_path):
+    app = _app(tmp_path)
+    _client(app).post("/enroll", data={"recovery": app.state.admin_token,
+                                       "password": PASSWORD,
+                                       "confirm": PASSWORD})
+    _enrol_passkey(_owner(app))
+    c = _client(app)
+    assert c.post("/login", data={"password": PASSWORD},
+                  follow_redirects=False).status_code == 303
+
+
+# ── what must fail, fails ───────────────────────────────────────────────────
+
+def test_assertion_for_another_origin_is_refused(tmp_path):
+    app = _app(tmp_path)
+    pk, _ = _enrol_passkey(_owner(app))
+    c = _client(app)
+    # signed clientDataJSON claims a different origin than the ceremony's
+    r = _passkey_login(c, pk, mangle="https://evil.example")
+    assert r.status_code == 401
+    assert "mm_admin" not in c.cookies
+    assert c.get("/v1/facts").status_code == 401
+
+
+def test_unknown_credential_is_refused(tmp_path):
+    app = _app(tmp_path)
+    _enrol_passkey(_owner(app))
+    stranger = SoftPasskey()  # valid crypto, never enrolled
+    r = _passkey_login(_client(app), stranger)
+    assert r.status_code == 401
+
+
+def test_login_before_any_enrolment_has_no_options(tmp_path):
+    app = _app(tmp_path)
+    r = _client(app).post("/webauthn/login/options",
+                          headers={"Origin": LOCAL_ORIGIN})
+    assert r.status_code == 400
+
+
+def test_challenge_is_single_use(tmp_path):
+    app = _app(tmp_path)
+    pk, _ = _enrol_passkey(_owner(app))
+    c = _client(app)
+    o = c.post("/webauthn/login/options", headers={"Origin": LOCAL_ORIGIN}).json()
+    cred = pk.assertion(o["publicKey"], LOCAL_ORIGIN)
+    first = c.post("/webauthn/login", json={"cid": o["cid"], "credential": cred},
+                   headers={"Origin": LOCAL_ORIGIN})
+    assert first.status_code == 200
+    replay = _client(app).post("/webauthn/login",
+                               json={"cid": o["cid"], "credential": cred},
+                               headers={"Origin": LOCAL_ORIGIN})
+    assert replay.status_code == 401  # the challenge died with its first use
+
+
+def test_sign_count_regression_is_refused(tmp_path):
+    """A counter that goes BACKWARDS means a cloned credential. Apple's
+    constant-zero counters never trip this (0 -> 0 verifies); a real regression
+    does."""
+    app = _app(tmp_path)
+    pk, _ = _enrol_passkey(_owner(app))
+    assert _passkey_login(_client(app), pk, sign_count=5).status_code == 200
+    assert _passkey_login(_client(app), pk, sign_count=3).status_code == 401
+    assert _passkey_login(_client(app), pk, sign_count=6).status_code == 200
+
+
+def test_duplicate_enrolment_is_refused(tmp_path):
+    app = _app(tmp_path)
+    owner = _owner(app)
+    pk, first = _enrol_passkey(owner)
+    assert first.status_code == 200
+    again = _enrol_passkey(owner, pk=pk)[1]
+    assert again.status_code == 409
+
+
+# ── per-origin enrolment: the tailnet host is its own RP ────────────────────
+
+def test_trusted_host_enrols_and_unlocks_separately(tmp_path):
+    app = _app(tmp_path, auth_token="tok-for-tailnet-test",
+               trusted_hosts=[TAILNET_HOST])
+    local_pk, _ = _enrol_passkey(_owner(app))
+
+    remote_owner = _owner(app, base_url=TAILNET_ORIGIN)
+    remote_pk, r = _enrol_passkey(remote_owner, origin=TAILNET_ORIGIN,
+                                  rp=TAILNET_HOST)
+    assert r.status_code == 200
+
+    # each credential unlocks its own origin...
+    anon_remote = _client(app, base_url=TAILNET_ORIGIN)
+    assert _passkey_login(anon_remote, remote_pk,
+                          origin=TAILNET_ORIGIN).status_code == 200
+    # ...and is invisible to the other (the localhost key signs the localhost
+    # RP hash, which cannot verify against the tailnet RP)
+    assert _passkey_login(_client(app, base_url=TAILNET_ORIGIN), local_pk,
+                          origin=TAILNET_ORIGIN).status_code == 401
+
+
+def test_untrusted_host_gets_no_ceremony(tmp_path):
+    app = _app(tmp_path, auth_token="tok")
+    c = _client(app, base_url="https://stranger.example", token="tok")
+    r = c.post("/webauthn/register/options",
+               headers={"Origin": "https://stranger.example"})
+    assert r.status_code == 400
+
+
+# ── lifecycle: persistence, restart, removal ────────────────────────────────
+
+def test_credentials_survive_a_restart_ceremonies_do_not(tmp_path):
+    app1 = _app(tmp_path)
+    pk, _ = _enrol_passkey(_owner(app1))
+    # an options challenge minted by instance 1...
+    o = _client(app1).post("/webauthn/login/options",
+                           headers={"Origin": LOCAL_ORIGIN}).json()
+
+    app2 = _app(tmp_path)  # restart on the same data dir
+    # ...is meaningless to instance 2 (in-memory ceremonies)
+    cred = pk.assertion(o["publicKey"], LOCAL_ORIGIN)
+    stale = _client(app2).post("/webauthn/login",
+                               json={"cid": o["cid"], "credential": cred},
+                               headers={"Origin": LOCAL_ORIGIN})
+    assert stale.status_code == 401
+    # but the CREDENTIAL persisted: a fresh ceremony on app2 unlocks
+    assert _passkey_login(_client(app2), pk).status_code == 200
+
+
+def test_removal_stops_unlocking_but_password_remains(tmp_path):
+    app = _app(tmp_path)
+    _client(app).post("/enroll", data={"recovery": app.state.admin_token,
+                                       "password": PASSWORD,
+                                       "confirm": PASSWORD})
+    owner = _owner(app)
+    pk, _ = _enrol_passkey(owner)
+    listed = owner.get("/webauthn/credentials").json()["credentials"]
+    assert len(listed) == 1 and listed[0]["rp_id"] == "localhost"
+
+    assert owner.delete(
+        f"/webauthn/credentials/{listed[0]['id']}").status_code == 200
+    assert owner.get("/webauthn/credentials").json()["credentials"] == []
+    # no options any more, and the old assertion path is gone with them
+    assert _client(app).post("/webauthn/login/options",
+                             headers={"Origin": LOCAL_ORIGIN}).status_code == 400
+    # the fallback is intact
+    c = _client(app)
+    assert c.post("/login", data={"password": PASSWORD},
+                  follow_redirects=False).status_code == 303
+
+
+def test_stored_record_is_public_material_only(tmp_path):
+    app = _app(tmp_path)
+    pk, _ = _enrol_passkey(_owner(app))
+    con = db.connect(app.state.settings.db_path)
+    try:
+        rows = passkeys.list_credentials(con)
+    finally:
+        con.close()
+    assert len(rows) == 1
+    rec = rows[0]
+    assert rec["rp_id"] == "localhost"
+    assert rec["origin"] == LOCAL_ORIGIN
+    # the stored public key is the COSE key the authenticator produced —
+    # and nothing resembling a private scalar is anywhere in the record
+    priv = pk.key.private_numbers().private_value.to_bytes(32, "big")
+    assert bytes_to_base64url(priv) not in json.dumps(rec)
+    assert base64url_to_bytes(rec["id"]) == pk.cred_id

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -35,7 +35,7 @@ from memory_service.config import Settings
 
 PASSWORD = "a-durable-owner-passphrase"
 LOCAL_ORIGIN = "http://localhost"
-TAILNET_HOST = "cat.tailtest.ts.net"
+TAILNET_HOST = "my-mac.my-tailnet.ts.net"
 TAILNET_ORIGIN = f"https://{TAILNET_HOST}:8443"
 
 


### PR DESCRIPTION
## What & why

Passkey (WebAuthn) login for the admin UI, closing #27: an enrolled Touch ID / iCloud Keychain passkey becomes the everyday unlock, the password stays one click behind it, and the recovery secret keeps its enrolment/reset role unchanged. Design decisions (per-origin enrolment; py_webauthn for verification) were agreed with the owner and recorded on the issue before implementation.

How it hangs together:

- `memory_service/passkeys.py`: credential storage in the durable `settings` table (public key + id only; append-style list, one record per origin) and the origin/RP policy: `localhost` always, trusted hosts (#83 boundary) over https, IP addresses never (browser rule, verified live before building: `SecurityError: This is an invalid domain` on 127.0.0.1).
- `api.py`: six `include_in_schema=False` endpoints. Register options/verify sit behind the same `_admin_auth` gate as exact-row reads, so enrolment is impossible from the lock screen; the two login steps join `LOGIN_SURFACE`. Challenges are server-side, single-use, 300s. Login failures are uniform 401s, matching the password path's single "incorrect". A successful assertion mints exactly the session a password login mints.
- Lock page: passkey-first layout only when the current origin has a credential; password behind a disclosure; error re-renders keep the password layout. `127.0.0.1` quietly stays password-first.
- Admin page: a Passkeys section (list, enrol, remove) with a plain-English explainer, including the one honest catch (per-address credentials).
- Credentials are enrolled as discoverable with user verification required, so login options disclose no credential ids to the anonymous lock screen.

Verified live on a scratch instance (scratch store, throwaway secret, deleted after): first-run password enrolment, passkey enrolment through the real page button, logout, passkey-first lock screen, unlock through the real button into the admin UI, and the 127.0.0.1 degradation. The soft authenticator used for that walk is the same byte-level construction the test suite uses; the only step not exercised end-to-end is the OS biometric sheet itself, which needs a human finger and is the natural first click of the review.

## Checklist

- [x] Tests green **keyless**: 358 passed (339 existing + 19 new), `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q`
- [x] No real personal data anywhere in the diff. Synthetic roster only (test tailnet host is `my-mac.my-tailnet.ts.net`)
- [x] The invariants still hold (settings-table auth state only, like the password verifier; no ledger writes)
- [x] CHANGELOG.md entry under Unreleased; SECURITY.md and docs/API.md updated in this PR
- [x] New UI surfaces have a plain-English "what is this & why it matters" explainer

Sibling: spendglass#22 mirrors this after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
