### PR TITLE
Guest speakers in ingest: attribution and quarantine-by-default (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- Guest speakers (#31): ingest accepts `guest:<name>` and `guest:unknown`
+  speaker values beside `user` and the model slugs (additive, contract
+  version unchanged). Facts mined from a guest's speech are held for
+  review with the guest's name in the stated reason, phrased in third
+  person as facts about the guest, never absorbed into the owner's
+  first-person profile. Speech from an unidentified or unrecognised
+  speaker is treated as untrusted the same way, so nothing new gains
+  trust by default; the owner's own turns are unchanged.
 - Mobile view (#29): the admin page, both lock screen layouts, and the
   Mathematics page are now usable at phone width. The lock screen tells
   phones its true size (viewport tag), controls stack and grow to touch

--- a/docs/API.md
+++ b/docs/API.md
@@ -265,7 +265,8 @@ does not promise a gate the service does not implement.
 ```json
 {"source_app": "multi-model-chat", "conversation_id": "chat-123",
  "title": "Weekend plans",
- "messages": [{"external_id": "m-1", "speaker": "user|<slug>",
+ "messages": [{"external_id": "m-1",
+                "speaker": "user|<slug>|guest:<name>|guest:unknown",
                 "content": "...", "created_at": "2026-07-04T10:00:00+10:00",
                 "attachments": [{"filename": "notes.txt", "mime": "text/plain",
                                   "data_b64": "..."}]}]}
@@ -276,6 +277,29 @@ does not promise a gate the service does not implement.
 later ingest of the same conversation, so a chat renamed in the client catches
 up here. It is the title `/search` hits carry back and the admin pages show;
 a client that never sends one leaves every conversation blank.
+
+`speaker` guest classes (additive, 2026-08-08, #31): beside `user` (the
+owner) and a bare model slug (`claude`), a message may carry `guest:<name>`
+for another, named human in the session (a multi-human voice session in
+room mode), or `guest:unknown` for a human turn whose voice diarization
+could not attribute confidently. `source_app` handling and conversation
+identity are untouched. What the classes mean downstream, in the mining
+pass:
+
+- A fact the miner draws from guest-attributed speech is quarantined by
+  default: written, then held in the review queue with the guest's name in
+  the stated reason, the same posture `mcp:*` writes get from the write
+  gate. `guest:unknown` speech quarantines unconditionally.
+- Pronouns resolve per speaker. A guest's first-person statement is a fact
+  about the guest, phrased into the owner's ledger in third person, never
+  absorbed into the owner's first-person profile. Guests get no profile of
+  their own: this service stays single-owner, and a guest's facts exist
+  only as facts about the owner's world. A fact about the owner asserted
+  by a guest is still guest-provenance and quarantines the same way.
+- Fail safe: any other class-prefixed speaker value (say `agent:scribe`)
+  is unrecognised and treated as untrusted, quarantining exactly like
+  guest speech, so a newer client can never mint trust by inventing a
+  class. Facts drawn from the owner's own `user` turns are unchanged.
 
 `attachments` (additive, 2026-07-11) is optional, per message. Files are part
 of the episodic record: bytes stored whole (content-addressed under

--- a/memory_service/mining.py
+++ b/memory_service/mining.py
@@ -1,8 +1,10 @@
 """The reflection pass — mine a conversation's new messages for durable facts.
 
-Every mined fact passes the four walls; a flag means written-but-quarantined
-(low confidence), never silently dropped. The episodic record is read-only
-input here — this pass never modifies a message.
+Every mined fact passes the four walls, plus the per-speaker trust check
+(#31: a fact drawn from a guest's or unrecognised speaker's turn is held for
+review with the speaker named in the reason); a flag means
+written-but-quarantined (low confidence), never silently dropped. The
+episodic record is read-only input here — this pass never modifies a message.
 """
 
 import re
@@ -154,7 +156,20 @@ def _msg_body(m: dict) -> str:
 
 
 def _speaker(m: dict, user_name: str) -> str:
-    return user_name if m["speaker"] == "user" else m["speaker"]
+    """The transcript label for one turn. The owner's turns carry their real
+    name; a guest's turns carry the guest's name plus a "(guest)" marker so
+    the extractor can attribute speech per speaker (#31); an unidentified
+    human turn is labelled as exactly that, never defaulted to the owner.
+    Model slugs and unrecognised values render verbatim."""
+    s = m["speaker"]
+    if s == "user":
+        return user_name
+    cls = walls.speaker_class(s)
+    if cls == "guest":
+        return f"{walls.guest_name(s)} (guest)"
+    if cls == "guest-unknown":
+        return "Unidentified speaker (guest)"
+    return s
 
 
 def _transcript(messages: list[dict], user_name: str) -> str:
@@ -238,12 +253,28 @@ def distill(con, settings, source_app: str, conversation_external_id: str,
         lock.release()
 
 
+# Speaker classes that count as HUMAN SPEECH worth mining (#31). Guest turns
+# mine even with the owner silent in the window — their facts land quarantined,
+# so nothing gains trust — but a window of only model turns and/or unrecognised
+# speaker classes skips the LLM exactly as model-only windows always have: an
+# unrecognised class is not known to be a human voice at all (it could be a
+# tool or a transcript artefact), so mining it as biography would guess.
+_HUMAN_SPEAKERS = ("owner", "guest", "guest-unknown")
+
+
 def _distill_chunk(con, settings, source_app: str, conv: dict,
                    new_msgs: list[dict]) -> dict:
-    if not any(m["speaker"] == "user" for m in new_msgs):
+    if not any(walls.speaker_class(m["speaker"]) in _HUMAN_SPEAKERS
+               for m in new_msgs):
         _advance(con, conv["id"], new_msgs[-1]["id"])
         return {"added": 0, "quarantined": 0, "deduped": 0,
                 "refused_supersede": 0, "deferred_supersede": 0}
+
+    # #31: does this window carry any speech that is NOT the owner's or a model
+    # seat's? If so, a fact with no valid src= binding cannot be attributed to
+    # the owner, and the fail-safe below holds it for review.
+    untrusted_speaker_present = any(
+        walls.speaker_trust_flag(m["speaker"]) for m in new_msgs)
 
     source_text = _transcript(new_msgs, settings.user_name)
     recent = ledger.list_facts(con, status="valid", limit=250)
@@ -264,6 +295,25 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
     # The [msg N] labels in source_text map back to real messages here; a fact's
     # src=N is validated against this before it can narrow event-date grounding.
     idx_to_msg = {i: m for i, m in enumerate(new_msgs, start=1)}
+    # Guest guidance enters the prompt only when the window actually carries
+    # guest (or unrecognised) speech, so the everyday owner-only path pays
+    # nothing and its prompt is byte-identical to before (#31).
+    guest_rules = "" if not untrusted_speaker_present else (
+        "GUEST SPEAKERS: turns labelled \"(guest)\" are OTHER HUMANS in the "
+        f"session — never {settings.user_name} and never an AI participant. "
+        "Resolve pronouns PER SPEAKER: a guest's 'I' is that guest, not "
+        f"{settings.user_name}. Phrase a guest's fact in third person, naming "
+        "the guest (e.g. a guest called Sam saying 'I hate coriander' becomes "
+        f"'{settings.user_name}'s wife Sam dislikes coriander' when the "
+        "excerpt states that relationship, else 'Sam (a guest) dislikes "
+        f"coriander') — NEVER as a first-person fact about "
+        f"{settings.user_name}. Do not build a profile of a guest: extract a "
+        "guest's statement only when it matters to understanding "
+        f"{settings.user_name}'s world (family, close relationships, shared "
+        "plans, things that affect them). Speech from an unidentified speaker "
+        "may still be extracted, attributed to 'an unidentified guest'. Every "
+        "fact drawn from a guest's turn must carry src=<N> naming that "
+        "guest's own turn.\n")
     prompt = (
         f"You maintain a permanent memory ledger about {settings.user_name}. From the "
         "conversation excerpt below, extract durable facts worth remembering long-term. "
@@ -300,6 +350,7 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         "roleplay, persona, or interview-prep framing, or from an assistant's own "
         "'what do you know about me' summary; or anything already in the existing "
         "entries.\n"
+        f"{guest_rules}"
         "Each turn in the excerpt is prefixed with a [msg N] label. Every fact must "
         "carry src=<N> naming the SINGLE message it was drawn from — copy the label "
         "off that turn, do not count. If a fact draws on a few adjacent turns, cite "
@@ -427,6 +478,24 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         # a fact may legitimately synthesise across turns, and #33 is about the
         # event date only — narrowing the walls here would be scope creep.
         flags = walls.check(fact, source_text, allow)
+        # #31: source-trust for WHO SPOKE. A fact bound to a guest's turn, an
+        # unidentified speaker's, or an unrecognised speaker class's is held
+        # for review with the speaker named in the reason — the same posture
+        # `mcp:*` writes get from the ledger gate. And when such turns exist in
+        # the window but the fact carries no valid binding at all, it cannot be
+        # attributed to the owner, so it is held too (fail safe — attribution
+        # is exactly what this window can no longer assume). Owner-only
+        # windows are unchanged: an unbound fact there behaves as it always
+        # has, because every human turn is the owner's.
+        if bound is not None:
+            speaker_flag = walls.speaker_trust_flag(bound["speaker"])
+        else:
+            speaker_flag = (
+                "speaker-trust: no valid src= binding in a session with guest "
+                "or unrecognised speakers — cannot attribute this fact to the "
+                "owner") if untrusted_speaker_present else None
+        if speaker_flag:
+            flags = flags + [speaker_flag]
         if importance is None:
             # #69: still unscored AFTER the corrective retry — the backstop.
             # Quarantine, don't silently trust.

--- a/memory_service/walls.py
+++ b/memory_service/walls.py
@@ -24,6 +24,18 @@ vocabulary, never the generic verbs or product names a real career/project
 decision or preference would use, so a fact like "Alex shipped the v2 redesign"
 or "Alex prefers dark-mode UIs" is judged by the quarantine walls like anything
 else, never silently dropped here.
+
+`speaker_class` / `speaker_trust_flag` (#31) extend the source-trust posture
+to WHO SPOKE. Ingest may attribute turns to other humans in the room
+(`guest:<name>`, or `guest:unknown` when diarization could not identify the
+voice confidently). A fact the miner draws from such a turn is quarantined by
+default, with the speaker named in the stated reason: the same held-for-review
+treatment `mcp:*` writes get from the ledger gate, never a silent drop and
+never silent trust. Any speaker class this build does not recognise is treated
+the same way (fail safe), so a newer client can never mint trust by inventing
+a class. The owner's own `user` turns and the model seats are unchanged.
+These checks live here beside the other walls; the mining pass supplies the
+per-fact speaker binding, so `check()` below is unchanged.
 """
 
 import re
@@ -255,6 +267,68 @@ def source_trusted(source_text: str) -> bool:
     """False if the chat is roleplay/persona/prep or an AI dossier — its 'facts'
     may be fiction or the model's own claims, not biography."""
     return not _PERSONA_RE.search(source_text or "")
+
+
+# ── speaker classes (#31) ────────────────────────────────────────────────────
+#
+# Ingest speaker values, classified once, here, for every consumer. The wire
+# grammar is additive to contract 1.1: `user` and bare model slugs are the
+# classes that always existed; `guest:<name>` and `guest:unknown` arrived with
+# multi-human voice sessions (crossband room mode). Anything else that carries
+# a class prefix is a class this build does not know, and fail-safe means it
+# behaves as untrusted rather than silently gaining the owner's trust.
+
+def speaker_class(speaker: str) -> str:
+    """Classify one ingest `speaker` value.
+
+    'owner'         - "user": the human this ledger is about.
+    'model'         - a bare participant slug ("claude"): an AI seat.
+    'guest'         - "guest:<name>": another, named human in the session.
+    'guest-unknown' - "guest:unknown" (or a nameless "guest:"): a human turn
+                      diarization could not attribute confidently.
+    'unrecognised'  - any other class-prefixed or empty value: a speaker class
+                      this build does not know. Treated as untrusted.
+    """
+    s = (speaker or "").strip()
+    if s == "user":
+        return "owner"
+    if ":" not in s:
+        return "model" if s else "unrecognised"
+    prefix, name = s.split(":", 1)
+    if prefix.strip().lower() == "guest":
+        name = name.strip()
+        if not name or name.lower() == "unknown":
+            return "guest-unknown"
+        return "guest"
+    return "unrecognised"
+
+
+def guest_name(speaker: str) -> str | None:
+    """The guest's name from a `guest:<name>` speaker; None for every other
+    class (including `guest:unknown`, which by definition has no name)."""
+    if speaker_class(speaker) != "guest":
+        return None
+    return speaker.strip().split(":", 1)[1].strip()
+
+
+def speaker_trust_flag(speaker: str) -> str | None:
+    """The source-trust wall applied to WHO SPOKE (#31). None for the two
+    classes mining has always consumed (the owner's `user` turns and the model
+    seats); otherwise a quarantine flag naming the speaker, so a fact drawn
+    from that turn is written but held for review — the same posture `mcp:*`
+    writes get from the ledger gate. `guest:unknown` and unrecognised classes
+    quarantine unconditionally: no name means no one to ever earn trust."""
+    cls = speaker_class(speaker)
+    if cls in ("owner", "model"):
+        return None
+    if cls == "guest":
+        return (f"guest-attribution: stated by guest {guest_name(speaker)}, "
+                "not the owner")
+    if cls == "guest-unknown":
+        return ("guest-attribution: speaker unidentified (diarization could "
+                "not attribute this turn confidently)")
+    return (f"speaker-trust: unrecognised speaker class {speaker!r}, "
+            "treated as untrusted")
 
 
 def is_system_meta(fact: str) -> bool:

--- a/tests/test_guest_speakers.py
+++ b/tests/test_guest_speakers.py
@@ -1,0 +1,271 @@
+"""Guest speakers in ingest (#31): attribution and quarantine-by-default.
+
+Multi-human voice sessions attribute turns to named humans beside the owner
+(`guest:<name>`) or mark them unidentified (`guest:unknown`). Facts mined
+from such speech are written but held for review with the speaker named in
+the reason — the posture `mcp:*` writes already get — and a guest's
+first-person statement lands in the owner's ledger in third person, never as
+first-person biography about the owner. Unrecognised speaker classes are
+untrusted by default, so a newer client never silently gains trust.
+"""
+
+from memory_service import episodic, ledger, mining, walls
+
+
+def _ingest(con, msgs, conv="room-1"):
+    episodic.ingest(con, "multi-model-chat", conv, [
+        {"external_id": f"m{i}", "speaker": sp, "content": text,
+         "created_at": 1700000000.0 + i * 60}
+        for i, (sp, text) in enumerate(msgs, start=1)], title="Kitchen chat")
+    return conv
+
+
+# ── speaker classification (walls) ──────────────────────────────────────────
+
+
+def test_speaker_classes():
+    assert walls.speaker_class("user") == "owner"
+    assert walls.speaker_class("claude") == "model"
+    assert walls.speaker_class("gpt-5") == "model"
+    assert walls.speaker_class("guest:Sam") == "guest"
+    assert walls.speaker_class("Guest:Sam") == "guest"          # prefix case-blind
+    assert walls.speaker_class("guest:unknown") == "guest-unknown"
+    assert walls.speaker_class("guest:Unknown") == "guest-unknown"
+    assert walls.speaker_class("guest:") == "guest-unknown"     # nameless guest
+    assert walls.speaker_class("agent:scribe") == "unrecognised"
+    assert walls.speaker_class("tool:web-search") == "unrecognised"
+    assert walls.speaker_class("") == "unrecognised"
+
+
+def test_guest_name_extraction():
+    assert walls.guest_name("guest:Sam") == "Sam"
+    assert walls.guest_name("guest: Sam ") == "Sam"
+    assert walls.guest_name("guest:unknown") is None
+    assert walls.guest_name("user") is None
+    assert walls.guest_name("claude") is None
+
+
+def test_speaker_trust_flags():
+    assert walls.speaker_trust_flag("user") is None      # the owner: unchanged
+    assert walls.speaker_trust_flag("claude") is None    # model seat: unchanged
+    named = walls.speaker_trust_flag("guest:Sam")
+    assert "guest" in named and "Sam" in named
+    unknown = walls.speaker_trust_flag("guest:unknown")
+    assert "unidentified" in unknown
+    other = walls.speaker_trust_flag("agent:scribe")
+    assert "unrecognised" in other and "agent:scribe" in other
+
+
+# ── transcript rendering and prompt guidance ────────────────────────────────
+
+
+def test_transcript_labels_guests():
+    msgs = [
+        {"speaker": "user", "content": "Hello there."},
+        {"speaker": "guest:Sam", "content": "Hi, it's me."},
+        {"speaker": "guest:unknown", "content": "And someone else."},
+        {"speaker": "claude", "content": "Welcome, everyone."},
+    ]
+    text = mining._transcript(msgs, "Alex")
+    assert "[msg 1] Alex:" in text
+    assert "[msg 2] Sam (guest):" in text
+    assert "[msg 3] Unidentified speaker (guest):" in text
+    assert "[msg 4] claude:" in text
+
+
+def test_prompt_guest_guidance_only_when_guests_present(
+        con, settings, sample_conversation, fake_llm):
+    _ingest(con, [
+        ("user", "Sam is here with me."),
+        ("guest:Sam", "I hate coriander."),
+    ], conv="room-p")
+    fake_llm["response"] = "NONE"
+    mining.distill(con, settings, "multi-model-chat", "room-p", regenerate=False)
+    assert "GUEST SPEAKERS" in fake_llm["prompts"][0]
+    # The everyday owner-only path carries no guest guidance at all.
+    mining.distill(con, settings, "multi-model-chat", "chat-1", regenerate=False)
+    assert "GUEST SPEAKERS" not in fake_llm["prompts"][1]
+
+
+# ── quarantine-by-default for guest-derived facts ───────────────────────────
+
+
+def test_guest_first_person_fact_quarantined_with_guest_name(
+        con, settings, fake_llm):
+    # A guest's "I hate coriander" is a fact about the GUEST, phrased in third
+    # person into the owner's ledger — and held for review, never canon on
+    # sight, with the guest named in the reason.
+    _ingest(con, [
+        ("user", "Sam and I are planning the Fairhaven trip."),
+        ("guest:Sam", "I hate coriander, please leave it out of everything."),
+    ])
+    fake_llm["response"] = (
+        "NEW src=2 importance=4: Alex's wife Sam dislikes coriander.")
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}   # written AND held
+    assert ledger.list_facts(con, status="valid") == []
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert "guest" in held["quarantine_reason"]
+    assert "Sam" in held["quarantine_reason"]
+    assert held["confidence"] == "low"
+    # The review flow is the same as for any held fact: an owner approval
+    # makes it canon, third-person phrasing and all.
+    ledger.approve(con, held["id"])
+    assert any(f["id"] == held["id"]
+               for f in ledger.list_facts(con, status="valid"))
+
+
+def test_owner_speech_unchanged_in_mixed_session(con, settings, fake_llm):
+    # The owner's own turns keep their existing trust even with a guest in the
+    # room: only the guest-bound fact is held.
+    _ingest(con, [
+        ("user", "I have signed up for the Fairhaven half marathon."),
+        ("guest:Sam", "And I am doing the ten kilometre run."),
+    ])
+    fake_llm["response"] = (
+        "NEW src=1 importance=5: Alex signed up for the Fairhaven half marathon.\n"
+        "NEW src=2 importance=4: Alex's wife Sam is doing the ten kilometre run.")
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 2, "quarantined": 1}
+    valid = ledger.list_facts(con, status="valid")
+    assert len(valid) == 1 and "marathon" in valid[0]["content"]
+    held = ledger.list_facts(con, status="quarantined")
+    assert len(held) == 1 and "Sam" in held[0]["content"]
+
+
+def test_fact_about_owner_from_guest_speech_still_quarantines(
+        con, settings, fake_llm):
+    # Guest-provenance is about WHO SPOKE, not who the fact mentions: a claim
+    # ABOUT the owner asserted by a guest still quarantines by default.
+    _ingest(con, [
+        ("user", "Let's sort out dinner."),
+        ("guest:Sam", "Remember Alex is allergic to shellfish."),
+    ])
+    fake_llm["response"] = "NEW src=2 importance=7: Alex is allergic to shellfish."
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert "Sam" in held["quarantine_reason"]
+
+
+def test_guest_unknown_quarantines_unconditionally(con, settings, fake_llm):
+    _ingest(con, [
+        ("user", "Who else is in the room?"),
+        ("guest:unknown", "I grew up in Fairhaven."),
+    ])
+    fake_llm["response"] = (
+        "NEW src=2 importance=3: A guest of Alex's grew up in Fairhaven.")
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert "unidentified" in held["quarantine_reason"]
+
+
+def test_unrecognised_speaker_class_is_untrusted(con, settings, fake_llm):
+    # Fail safe: a speaker class this build does not know behaves as
+    # untrusted, so a newer client never silently gains trust.
+    _ingest(con, [
+        ("user", "Planning the week."),
+        ("agent:scribe", "Alex works at Initech."),
+    ])
+    fake_llm["response"] = "NEW src=2 importance=5: Alex works at Initech."
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert "unrecognised" in held["quarantine_reason"]
+    assert "agent:scribe" in held["quarantine_reason"]
+
+
+def test_unbound_fact_in_guest_session_quarantines(con, settings, fake_llm):
+    # Fail safe for a missing src= binding: in a session with guest turns, a
+    # fact that names no source turn cannot be attributed to the owner, so it
+    # is held. (In an owner-only session an unbound fact stays valid, as
+    # test_missing_src_falls_back_to_conversation_time proves.)
+    _ingest(con, [
+        ("user", "We are planning this week's meals."),
+        ("guest:Sam", "I hate coriander."),
+    ])
+    fake_llm["response"] = "NEW importance=4: Alex's wife Sam dislikes coriander."
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert "src=" in held["quarantine_reason"]
+    assert "guest" in held["quarantine_reason"]
+
+
+def test_guest_only_chunk_still_mined(con, settings, fake_llm):
+    # The owner can be silent in a window; a guest's speech still mines, and
+    # everything it yields is held for review.
+    _ingest(con, [
+        ("guest:Sam", "I have started a new job at Globex."),
+        ("claude", "Congratulations on the Globex role!"),
+    ])
+    fake_llm["response"] = (
+        "NEW src=1 importance=5: Sam (a guest) has started a new job at Globex.")
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}
+    assert fake_llm["prompts"]      # the miner ran
+    assert ledger.list_facts(con, status="valid") == []
+
+
+def test_unrecognised_only_chunk_skips_mining(con, settings, fake_llm):
+    # A window of only unrecognised-class and model turns is not known to be
+    # human speech at all — no mining call, exactly like model-only windows.
+    _ingest(con, [
+        ("agent:scribe", "Meeting notes: budget approved."),
+        ("claude", "Noted."),
+    ])
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 0, "quarantined": 0}
+    assert fake_llm["prompts"] == []
+
+
+# ── ingest accepts the new class (additive contract) ────────────────────────
+
+
+def test_ingest_stores_guest_speakers_verbatim(con, settings):
+    _ingest(con, [
+        ("user", "Dinner planning time."),
+        ("guest:Sam", "No coriander for me."),
+        ("guest:unknown", "And someone else spoke."),
+    ], conv="room-v")
+    conv = episodic.get_conversation(con, "multi-model-chat", "room-v")
+    rows = episodic.messages_after(con, conv["id"], 0)
+    assert [r["speaker"] for r in rows] == ["user", "guest:Sam", "guest:unknown"]
+    # Idempotent like any other ingest: a re-send inserts nothing new.
+    res = episodic.ingest(con, "multi-model-chat", "room-v", [
+        {"external_id": "m2", "speaker": "guest:Sam",
+         "content": "No coriander for me.", "created_at": 1700000120.0}])
+    assert res["ingested"] == 0 and res["skipped"] == 1
+
+
+def test_http_ingest_accepts_guest_speakers(settings, fake_llm):
+    from fastapi.testclient import TestClient
+
+    from memory_service.api import create_app
+    app = create_app(settings)
+    client = TestClient(app, base_url="http://127.0.0.1")
+    r = client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "room-h",
+        "title": "Kitchen chat",
+        "messages": [
+            {"external_id": "m1", "speaker": "user",
+             "content": "Dinner planning time.",
+             "created_at": "2026-08-08T10:00:00+10:00"},
+            {"external_id": "m2", "speaker": "guest:Sam",
+             "content": "No coriander for me.",
+             "created_at": "2026-08-08T10:01:00+10:00"},
+            {"external_id": "m3", "speaker": "guest:unknown",
+             "content": "And someone else spoke.",
+             "created_at": "2026-08-08T10:02:00+10:00"},
+        ]})
+    assert r.status_code == 200
+    assert r.json() == {"ingested": 3, "skipped": 0, "attached": 0}


### PR DESCRIPTION
## What & why

Closes #31 (the membro half of crossband#28 phase 3). Ingest now accepts `guest:<name>` and `guest:unknown` speaker values beside `user` and the model slugs, additively: contract version, `source_app` handling, and conversation identity are all untouched. Facts the miner draws from a guest's turn are held for review with the guest named in the stated reason (the posture `mcp:*` writes already get); `guest:unknown` and any unrecognised speaker class quarantine unconditionally, so a newer client never silently gains trust. Pronouns resolve per speaker: a guest's first-person statement lands in the owner's ledger in third person as a fact about the guest, never as first-person biography about the owner, and guests get no profile of their own. The owner's own `user` turns are unchanged, and their unbound-fact behaviour in owner-only sessions is byte-identical to before.

## Checklist

- [x] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q` (373 passed; 358 before this change, 15 added)
- [x] No real personal data anywhere in the diff. Synthetic roster only ; Alex, wife Sam, daughter Maya, Fairhaven as the stock place name, stock fictional companies (Initech, Globex); a name outside the roster is a review question by definition
- [x] The invariants still hold (append-only; episodic record immutable; quarantine honored ; `tests/test_invariants.py`)
- [x] CHANGELOG.md entry under Unreleased in this same PR if this is user-visible; docs updated if they now lie
- [ ] New UI surfaces have a plain-English "what is this & why it matters" explainer (not applicable: no UI surface changes; the review queue shows the new quarantine reasons through its existing rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)