### PR TITLE
Detect and repair FTS5 desync behind zero-result message search

### DIFF
--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -934,11 +934,17 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         # record of what was dropped. Lives in `detail`, which is explicitly
         # documented as non-contractual and may change without a version bump.
         h["dropped_by_reason"] = walls.drop_diagnostics()
+        # fts_in_sync degrades status too: an out-of-sync search index means
+        # search_history/​/v1/search silently returns zero for real data —
+        # a startup repair (db.repair_fts) should have already fixed this,
+        # so seeing it here means the repair itself needs attention.
+        ok = h["integrity"] == "ok" and h["fts_in_sync"]
         return {
-            "status": "ok" if h["integrity"] == "ok" else "degraded",
+            "status": "ok" if ok else "degraded",
             "contract_version": settings.contract_version,
             "db": {"facts": h["facts"]["total"], "messages": h["messages"],
                     "size_bytes": h["size_bytes"], "integrity": h["integrity"],
+                    "fts_in_sync": h["fts_in_sync"],
                     "last_backup_at": h["last_backup_at"]},
             "capabilities": {"embeddings": embeddings.available(),
                               "miner_model": settings.miner_model},

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -170,9 +170,82 @@ def init(settings) -> None:
         con.executescript(SCHEMA)
         con.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         con.commit()
+        # Cheap (row-count comparison) and safe (no-op unless desynced) — see
+        # repair_fts. Runs every startup so a desynced search index can never
+        # sit silent indefinitely; a repair is logged loudly since it means
+        # search was returning zero results until now.
+        repaired = repair_fts(con)
+        if repaired["repaired"]:
+            log.warning("startup FTS repair: rebuilt %s (was out of sync with "
+                        "its base table — search was silently returning zero "
+                        "results for affected data)", repaired["repaired"])
     finally:
         con.close()
     os.chmod(settings.db_path, 0o600)
+
+
+# ---- FTS5 external-content sync (#issue: search returning zero results) ----
+#
+# messages_fts / attachments_fts are external-content FTS5 tables: they hold
+# no data of their own, only a shadow index, kept current solely by the
+# AFTER INSERT triggers in SCHEMA. Nothing ever backfills them from an
+# existing base table. If the virtual table is ever dropped and silently
+# recreated empty (schema experiment, corruption recovery, a partial
+# restore that copied `messages` but not the `messages_fts` shadow tables),
+# the index desyncs from its base table forever — MATCH queries then just
+# return zero rows, no error, so callers never learn anything is wrong (the
+# LIKE fallback in episodic.search only fires on an exception, not on an
+# empty-but-successful MATCH). fts_status/repair_fts close that gap: a cheap
+# row-count comparison, and the documented `('rebuild')` command to
+# resync — safe to run any number of times, including when already in sync.
+#
+# The count has to come from the `_docsize` shadow table, NOT
+# `SELECT COUNT(*) FROM <fts_table>`: for an external-content table, a
+# non-MATCH query against the fts5 table itself is answered by reading
+# straight through to the content table (that's the whole point of
+# "external content" — no duplicate storage), so it returns the base
+# table's count even when the FTS index proper is completely empty. The
+# `_docsize` shadow table holds one row per rowid actually indexed by FTS5,
+# so it — and only it — reflects the index's real state. (Confirmed
+# empirically: dropping+recreating the virtual table left `_docsize` at 0
+# while a plain COUNT(*) on the fts table still read through to the base
+# table's row count.)
+FTS_TABLES = (("messages", "messages_fts"), ("attachments", "attachments_fts"))
+
+
+def fts_status(con: sqlite3.Connection) -> dict:
+    """Row-count comparison between each base table and its external-content
+    FTS5 index's `_docsize` shadow table (see note above — NOT a plain
+    COUNT(*) on the fts5 table, which reads through to the base table and
+    would always claim to be in sync). Tables that don't exist yet
+    (older/partial schema) are skipped rather than raising."""
+    status = {}
+    for base, fts in FTS_TABLES:
+        try:
+            base_n = con.execute(f"SELECT COUNT(*) FROM {base}").fetchone()[0]
+            fts_n = con.execute(
+                f"SELECT COUNT(*) FROM {fts}_docsize").fetchone()[0]
+        except sqlite3.OperationalError:
+            continue
+        status[fts] = {"base_table": base, "base_rows": base_n,
+                       "fts_rows": fts_n, "in_sync": base_n == fts_n}
+    return status
+
+
+def repair_fts(con: sqlite3.Connection) -> dict:
+    """Idempotent: rebuild any external-content FTS5 index whose row count
+    disagrees with its base table. A no-op (no writes) when everything is
+    already in sync. Returns {"checked": [...], "repaired": [...]} — never
+    touches `messages`/`attachments` themselves, only their derived index."""
+    status = fts_status(con)
+    repaired = []
+    for fts, s in status.items():
+        if not s["in_sync"]:
+            con.execute(f"INSERT INTO {fts}({fts}) VALUES('rebuild')")
+            repaired.append(fts)
+    if repaired:
+        con.commit()
+    return {"checked": list(status), "repaired": repaired}
 
 
 def now() -> float:
@@ -345,6 +418,10 @@ def health(settings) -> dict:
         att = con.execute(
             "SELECT COUNT(*), COALESCE(SUM(size),0), "
             "COALESCE(SUM(extracted_text != ''),0) FROM attachments").fetchone()
+        # Surfaces the search-index-desync class of bug (previously silent:
+        # an empty/short FTS index just returns zero matches, no error) as an
+        # explicit, checkable field instead — see repair_fts.
+        fts = fts_status(con)
     finally:
         con.close()
     bdir = settings.data_dir / "backups"
@@ -361,6 +438,8 @@ def health(settings) -> dict:
         "messages": messages,
         "conversations": conversations,
         "attachments": {"total": att[0], "bytes": att[1], "searchable": att[2]},
+        "fts": fts,
+        "fts_in_sync": all(v["in_sync"] for v in fts.values()),
         "last_backup_at": snaps[-1].stat().st_mtime if snaps else None,
         "backups_kept": len(snaps),
     }

--- a/scripts/rebuild_fts.py
+++ b/scripts/rebuild_fts.py
@@ -1,0 +1,73 @@
+"""Manual trigger for the FTS5 desync repair that also runs automatically on
+every db.init() (service startup).
+
+Context: messages_fts / attachments_fts are external-content FTS5 indexes,
+kept current only by an AFTER INSERT trigger on their base table. Nothing
+backfills them from existing rows. If the virtual table is ever dropped and
+recreated (schema experiment, corruption recovery, a partial restore that
+copied the base table but not its FTS shadow tables), the index goes stale
+forever: MATCH queries succeed but find nothing, silently, with no error —
+search_history / POST /v1/search return zero results for real data even for
+generic terms, while everything else (recall, the fact ledger) is unaffected.
+
+This script is a standalone way to check/fix that on an already-running
+instance without waiting for (or forcing) a restart. It is safe to run any
+number of times: `fts_status` only rebuilds a table when its row count
+disagrees with its base table, and `INSERT INTO <fts>(<fts>) VALUES('rebuild')`
+touches only the derived index, never `messages`/`attachments` themselves.
+
+Usage:
+  .venv/bin/python scripts/rebuild_fts.py [--data-dir PATH] [--check]
+
+  --check   report status only, make no changes (exit 1 if anything is
+            out of sync, for use in a monitoring/cron check)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from memory_service import db  # noqa: E402
+from memory_service.config import load_settings  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--data-dir", type=Path, default=None)
+    ap.add_argument("--check", action="store_true",
+                    help="report only, make no changes")
+    args = ap.parse_args()
+
+    settings = load_settings()
+    if args.data_dir:
+        settings = settings.model_copy(update={"data_dir": args.data_dir.resolve()})
+
+    con = db.connect(settings.db_path)
+    try:
+        status = db.fts_status(con)
+        if not status:
+            print(f"no FTS tables found in {settings.db_path}")
+            return 0
+        out_of_sync = [fts for fts, s in status.items() if not s["in_sync"]]
+        for fts, s in status.items():
+            mark = "OK" if s["in_sync"] else "OUT OF SYNC"
+            print(f"  {fts}: {s['fts_rows']} indexed rows vs "
+                  f"{s['base_rows']} in {s['base_table']} — {mark}")
+        if not out_of_sync:
+            print("all FTS indexes in sync; nothing to do")
+            return 0
+        if args.check:
+            print(f"OUT OF SYNC: {out_of_sync} (re-run without --check to repair)")
+            return 1
+        result = db.repair_fts(con)
+        print(f"rebuilt: {result['repaired']}")
+    finally:
+        con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_fts_repair.py
+++ b/tests/test_fts_repair.py
@@ -1,0 +1,141 @@
+"""FTS5 external-content indexes (messages_fts, attachments_fts) are only
+kept current by an AFTER INSERT trigger on their base table — nothing
+backfills them from existing rows. These tests guard the failure mode
+diagnosed as the cause of search_history returning zero results for every
+query: the index silently going out of sync with its base table (e.g. a
+dropped/recreated virtual table), which MATCH queries survive without
+raising, so callers never learn anything is wrong."""
+
+from memory_service import db, episodic
+
+
+def test_fts_tracks_messages_on_ingest(con):
+    """The ordinary path: ingest keeps messages_fts row-for-row with
+    messages via the trigger, with no separate step required."""
+    status = db.fts_status(con)
+    assert status["messages_fts"]["base_rows"] == 0
+    assert status["messages_fts"]["fts_rows"] == 0
+    assert status["messages_fts"]["in_sync"] is True
+
+    episodic.ingest(con, "multi-model-chat", "chat-1", [
+        {"external_id": "m1", "speaker": "user", "content": "an issue to track",
+         "created_at": 1700000000.0},
+        {"external_id": "m2", "speaker": "claude", "content": "a follow-up TODO",
+         "created_at": 1700000060.0},
+    ])
+
+    status = db.fts_status(con)
+    assert status["messages_fts"]["base_rows"] == 2
+    assert status["messages_fts"]["fts_rows"] == 2
+    assert status["messages_fts"]["in_sync"] is True
+    assert episodic.search(con, "issue")
+    assert episodic.search(con, "TODO")
+
+
+def test_repair_fts_fixes_deliberately_emptied_index(con, sample_conversation):
+    """Simulate the diagnosed desync directly (drop + recreate the virtual
+    table empty, the same state a schema mishap or partial restore would
+    leave), then confirm search is silently broken, then confirm repair_fts
+    fixes it without touching `messages` itself."""
+    messages_before = [dict(r) for r in con.execute(
+        "SELECT * FROM messages ORDER BY id")]
+    assert messages_before  # sample_conversation ingested rows
+
+    # Reproduce the desync: drop and recreate the FTS shadow table empty,
+    # exactly what CREATE VIRTUAL TABLE IF NOT EXISTS leaves behind if the
+    # table was ever dropped after messages already existed.
+    con.execute("DROP TABLE messages_fts")
+    con.execute("CREATE VIRTUAL TABLE messages_fts USING fts5("
+                "content, content='messages', content_rowid='id')")
+    con.commit()
+
+    status = db.fts_status(con)
+    assert status["messages_fts"]["base_rows"] > 0
+    assert status["messages_fts"]["fts_rows"] == 0
+    assert status["messages_fts"]["in_sync"] is False
+
+    # This is the silent-failure symptom: no exception, just zero hits for
+    # content that is verifiably still in `messages`.
+    assert episodic.search(con, "Initech") == []
+
+    result = db.repair_fts(con)
+    assert result["repaired"] == ["messages_fts"]
+
+    status = db.fts_status(con)
+    assert status["messages_fts"]["in_sync"] is True
+    assert status["messages_fts"]["fts_rows"] == status["messages_fts"]["base_rows"]
+
+    hits = episodic.search(con, "Initech")
+    assert hits
+    assert any("Initech" in h["content"] for h in hits)
+
+    # The repair only touches the derived index, never the immutable
+    # episodic record itself.
+    messages_after = [dict(r) for r in con.execute(
+        "SELECT * FROM messages ORDER BY id")]
+    assert messages_after == messages_before
+
+
+def test_repair_fts_is_a_noop_when_in_sync(con, sample_conversation):
+    before = db.fts_status(con)
+    result = db.repair_fts(con)
+    assert result["repaired"] == []
+    after = db.fts_status(con)
+    assert before == after
+
+
+def test_init_repairs_a_desynced_index_on_startup(settings):
+    """db.init() runs the repair itself — a maintainer never has to know to
+    run the script for the fix to take effect on next restart."""
+    db.init(settings)
+    con = db.connect(settings.db_path)
+    try:
+        episodic.ingest(con, "multi-model-chat", "chat-1", [
+            {"external_id": "m1", "speaker": "user", "content": "an issue",
+             "created_at": 1700000000.0},
+        ])
+        con.execute("DROP TABLE messages_fts")
+        con.execute("CREATE VIRTUAL TABLE messages_fts USING fts5("
+                    "content, content='messages', content_rowid='id')")
+        con.commit()
+        assert db.fts_status(con)["messages_fts"]["in_sync"] is False
+    finally:
+        con.close()
+
+    db.init(settings)  # simulates a service restart
+
+    con = db.connect(settings.db_path)
+    try:
+        assert db.fts_status(con)["messages_fts"]["in_sync"] is True
+        assert episodic.search(con, "issue")
+    finally:
+        con.close()
+
+
+def test_health_surfaces_fts_desync(settings):
+    db.init(settings)
+    con = db.connect(settings.db_path)
+    try:
+        episodic.ingest(con, "multi-model-chat", "chat-1", [
+            {"external_id": "m1", "speaker": "user", "content": "hello",
+             "created_at": 1700000000.0},
+        ])
+    finally:
+        con.close()
+
+    h = db.health(settings)
+    assert h["fts_in_sync"] is True
+    assert h["fts"]["messages_fts"]["in_sync"] is True
+
+    con = db.connect(settings.db_path)
+    try:
+        con.execute("DROP TABLE messages_fts")
+        con.execute("CREATE VIRTUAL TABLE messages_fts USING fts5("
+                    "content, content='messages', content_rowid='id')")
+        con.commit()
+    finally:
+        con.close()
+
+    h = db.health(settings)
+    assert h["fts_in_sync"] is False
+    assert h["fts"]["messages_fts"]["in_sync"] is False


### PR DESCRIPTION
## Summary
- Diagnosed why `search_history`/`POST /v1/search` returned zero results for every query (including generic words like "issue"/"TODO") while `recall_memory` kept working fine: `messages_fts`/`attachments_fts` are external-content FTS5 indexes populated only by an `AFTER INSERT` trigger, with no backfill path anywhere. If that virtual table is ever dropped and recreated (schema tweak, corruption recovery, a partial restore), the index desyncs from its base table forever — `MATCH` queries succeed but find nothing, no exception, so `episodic.search`'s LIKE fallback (which only fires on error) never engages and the failure is completely silent. It is **not** a pending/unprocessed ingestion queue — ingestion writes `messages` and `messages_fts` synchronously in the same transaction; no such queue exists in this codebase.
- Adds `db.fts_status()` / `db.repair_fts()`: compares each base table's row count against its FTS index's *actual* indexed-row count (read from the `_docsize` shadow table — a plain `COUNT(*)` on the fts5 table itself reads through to the base table for external-content tables and would always falsely report "in sync") and reissues `INSERT INTO <fts>(<fts>) VALUES('rebuild')` when they disagree.
- Runs automatically on every `db.init()` (service startup) — cheap (two `COUNT(*)`s), a true no-op when already in sync, logs loudly if it actually had to repair something.
- Also exposed as `scripts/rebuild_fts.py` (with `--check` for a monitoring/cron-friendly exit code) so it can be run against a live instance without a restart.
- `db.health()` / `GET /v1/health` now surface `fts_in_sync` (and per-table counts under `fts`), and factor it into overall `status`, instead of the desync failing silently forever.
- Only the derived FTS index is ever touched by the repair — `messages`, `attachments`, and the fact ledger stay exactly as immutable/append-only as before.

## Test plan
- [x] New `tests/test_fts_repair.py`: FTS tracks `messages` through ordinary ingest; a deliberately emptied `messages_fts` (drop + recreate, reproducing the diagnosed failure) is detected, confirmed to break search silently, then repaired without touching `messages` itself; repair is a no-op when already in sync; `db.init()` repairs a desync on a simulated restart; `db.health()` surfaces the desync.
- [x] Full suite: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q` → **378 passed**.

## Note for the reviewer
Shawn approved this fix in chat but is driving right now and can't run the deploy/restart command. This PR is safe to sit as-is — it doesn't touch `.github/`, doesn't require an API key, and the fix is inert until the service is actually restarted (or `scripts/rebuild_fts.py` is run manually) against the live `data/` — nothing in this diff touches the live database itself. Merge/deploy whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
