### PR TITLE
Document the FTS health contract and the #37 repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ House convention: user-visible change, one line each, newest first.
   land as canon again instead of flooding the review queue under one
   generic reason; facts a retry binds to a guest's turn still hold with
   the guest named. Nothing about the walls or what quarantines changed.
+- FTS desync self-repair (#37): a search index that has fallen out of
+  step with the stored messages (dropped/recreated, so every search
+  returned zero rows without erroring) is detected and rebuilt
+  automatically at startup, `/health` reports `fts_in_sync` inside the
+  contractual `db` block and goes `degraded` while it is false, and
+  `scripts/rebuild_fts.py` repairs a live instance without a restart.
+  Messages, attachments and the fact ledger are untouched - the repair
+  only rebuilds the derived index.
 - Guest speakers (#31): ingest accepts `guest:<name>` and `guest:unknown`
   speaker values beside `user` and the model slugs (additive, contract
   version unchanged). Facts mined from a guest's speech are held for

--- a/docs/API.md
+++ b/docs/API.md
@@ -59,7 +59,7 @@ repo's CI (against the real service) and in each client's CI (against the stub).
   "status": "ok|degraded",
   "contract_version": "1.1",
   "db": {"facts": 0, "messages": 0, "size_bytes": 0, "integrity": "ok",
-          "last_backup_at": null},
+          "fts_in_sync": true, "last_backup_at": null},
   "capabilities": {"embeddings": true, "miner_model": "claude-haiku-4-5"},
   "detail": {"…admin surface, may change without a contract bump…"}
 }
@@ -69,7 +69,14 @@ light up; otherwise it runs memoryless.
 
 `status` is `"degraded"` rather than `"ok"` whenever SQLite's integrity check
 (`PRAGMA quick_check`) fails, which is the whole point of a health probe: a
-client can decline to write into a damaged file instead of piling on.
+client can decline to write into a damaged file instead of piling on. It is
+also `"degraded"` when `fts_in_sync` is false: the FTS index has fallen out
+of step with the stored messages (a dropped/recreated index is rebuilt empty
+and never refills on its own), which makes every `/search` return zero rows
+without erroring. The service detects and repairs this automatically at
+startup; `scripts/rebuild_fts.py` does the same for a live instance without a
+restart. A client seeing `fts_in_sync: false` should treat search results as
+unreliable until it flips back, not as an empty archive.
 `status`, `contract_version`, `db` and `capabilities` are contractual.
 `detail` is NOT: it repeats the entire internal health dict (sqlite version,
 journal mode, integrity, size, a facts breakdown of


### PR DESCRIPTION
Fixes #41. Doc-only: `fts_in_sync` added to the contractual `db` example, `degraded` semantics extended to FTS desync with client guidance, auto-repair and `scripts/rebuild_fts.py` named, and the missing #37 CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)