### PR TITLE
Record a fact's source turn only where it is real, and verify retry bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- Review evidence, and provenance only where it is real: a held fact now
+  shows the turn it came from — who said it and what they said — in the
+  review queue, on the admin page and in `GET /review`. A fact the miner
+  could not tie to one turn is stored unbound and says so, instead of
+  being pinned to whichever message happened to end the mining window.
+  And a src= binding the miner supplies on the corrective retry is now
+  checked against the turn it names, so a guest's sentence can no longer
+  be quietly approved as if you had said it. Nothing about what
+  quarantines changed.
 - Miner src= retry (#35): in a session with guest or unrecognised
   speakers, a fact the miner failed to bind to its source turn now gets
   one batched corrective re-ask before the fail-safe hold, the same

--- a/docs/API.md
+++ b/docs/API.md
@@ -307,6 +307,16 @@ pass:
   is unrecognised and treated as untrusted, quarantining exactly like
   guest speech, so a newer client can never mint trust by inventing a
   class. Facts drawn from the owner's own `user` turns are unchanged.
+- Provenance is recorded only where it is real (2026-08-12). A mined fact
+  carries `source_message_id` only when it was actually tied to one turn;
+  a fact the miner could not bind is stored unbound (`source_message_id`
+  null) rather than pinned to whichever turn ended the mining window. In a
+  guest-present window such a fact is still held for review, unchanged.
+  When the miner supplies a missing binding on the corrective retry, that
+  answer is now checked against the turn it names — a turn sharing none of
+  the fact's wording, or one no more plausible than a guest's turn in the
+  same window, is refused and the fact stays held. A retry's guess about
+  who spoke can no longer promote a guest's sentence into owner canon.
 
 `attachments` (additive, 2026-07-11) is optional, per message. Files are part
 of the episodic record: bytes stored whole (content-addressed under
@@ -426,6 +436,24 @@ admin token, even on loopback.**
 
 `GET /review`: held-for-review queue. **Requires the owner admin token, even
 on loopback.**
+
+Each row is the whole fact row plus `source` (additive, 2026-08-12, contract
+version unchanged): the turn the fact was mined from, so the first question a
+reviewer has — who said this — is answered without leaving the queue.
+```json
+"source": {"message_id": 812, "speaker": "guest:Sam", "speaker_class": "guest",
+           "created_at": 1754616000.0, "excerpt": "I hate coriander…",
+           "truncated": false}
+```
+`source` is `null` whenever the fact names no source message: an external
+(`mcp:*`) write, a fact saved by hand, or a mined fact that could not be tied
+to a single turn (see the guest-speaker notes above). It is never filled in
+with a nearby turn — "Sam said this" and "no one knows who said this" are
+different decisions, and a queue that blurs them is worse than one that stays
+silent. `excerpt` is the first 400 characters of the message's own content
+(attachment text is not included); `truncated` says whether more exists.
+`speaker_class` is the classification mining uses (`owner`, `model`, `guest`,
+`guest-unknown`, `unrecognised`).
 
 ## Recall & summary
 

--- a/docs/MEMORY_INTEGRITY.md
+++ b/docs/MEMORY_INTEGRITY.md
@@ -108,6 +108,16 @@ walls make the *write* safe instead. This trade-off is deliberate.
   "next Saturday") that its source never stated is quarantined for review. Before
   this, only proper nouns were checked, so a fact could carry a resolved date
   nobody wrote and still read as high-confidence.
+- **A card's source turn is recorded only when it is real.** A mined card
+  points at one message only when the extractor actually named that message,
+  and when the extractor has to be re-asked for a binding it omitted, the turn
+  it names must share the card's own wording — and must be at least as
+  plausible a source as any other speaker's turn in the same window. A card
+  nothing could be tied to is stored *unbound*, and the review queue says so,
+  rather than being attributed to whichever message happened to end the mining
+  window. Wrong provenance is quieter than a wrong fact and harder to unpick:
+  it makes a guest's sentence, or a synthesis of several turns, read like
+  something the owner said.
 - **A re-mine can't duplicate a card that's still current.** Two mining passes over
   one conversation can't overlap (a per-conversation lock), and a pass that writes
   facts and then dies before recording how far it read adds nothing on the retry: an

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -165,6 +165,45 @@ def _recall_out(f: dict) -> dict:
     return {k: f[k] for k in RECALL_FIELDS if k in f}
 
 
+# How much of the source turn a review row carries. Enough to judge "did this
+# person say this", not a transcript export: the whole message is one click
+# away in the episodic record for anyone who wants it.
+REVIEW_EXCERPT_CHARS = 400
+
+
+def _review_out(c, f: dict) -> dict:
+    """One review-queue row plus the turn it came from — speaker, speaker
+    class, and a bounded excerpt — but ONLY when the fact actually names a
+    source message that still exists.
+
+    A reviewer's first question about a held fact is "who said this", and the
+    queue could not answer it: the row carried a reason and nothing else. The
+    second rule matters as much as the first, though — an unbound fact (one
+    the miner could not tie to a single turn) gets `"source": null`, never a
+    nearby turn dressed up as its origin. "Sam said this" and "nobody knows
+    who said this" are different decisions, and the queue must not blur them.
+    """
+    out = dict(f)
+    row = None
+    if f.get("source_message_id") is not None:
+        row = c.execute(
+            "SELECT id, speaker, content, created_at FROM messages WHERE id=?",
+            (f["source_message_id"],)).fetchone()
+    if row is None:
+        out["source"] = None
+        return out
+    text = row["content"] or ""
+    out["source"] = {
+        "message_id": row["id"],
+        "speaker": row["speaker"],
+        "speaker_class": walls.speaker_class(row["speaker"]),
+        "created_at": row["created_at"],
+        "excerpt": text[:REVIEW_EXCERPT_CHARS],
+        "truncated": len(text) > REVIEW_EXCERPT_CHARS,
+    }
+    return out
+
+
 def _ts(iso: str | None) -> float | None:
     if not iso or not iso.strip():
         return None
@@ -1224,7 +1263,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
     def review():
         c = con()
         try:
-            return {"facts": ledger.review_queue(c)}
+            return {"facts": [_review_out(c, f) for f in ledger.review_queue(c)]}
         finally:
             c.close()
 

--- a/memory_service/mining.py
+++ b/memory_service/mining.py
@@ -5,6 +5,10 @@ Every mined fact passes the four walls, plus the per-speaker trust check
 review with the speaker named in the reason); a flag means
 written-but-quarantined (low confidence), never silently dropped. The
 episodic record is read-only input here — this pass never modifies a message.
+
+Provenance is recorded only where it is real: a fact this pass could not tie
+to one turn is stored UNBOUND (`source_message_id` NULL), never pinned to
+whichever turn happened to end the window.
 """
 
 import re
@@ -139,7 +143,9 @@ def _retry_src_bindings(unbound: list[tuple[int, str]], source_text: str,
     `turn_ids`. A src=none answer (honest cross-turn synthesis), a turn number
     the window doesn't contain, or missing/chatter output simply leaves that
     fact out of the map — the caller's existing fail-safe hold is the
-    unchanged backstop, never silent trust."""
+    unchanged backstop, never silent trust. Naming a real turn is necessary
+    but not sufficient: the caller checks every answer here against the turn
+    it names (`_repair_binding_refused`) before letting it grant trust."""
     listing = "\n".join(f"FACT {k}: {fact}"
                         for k, (_, fact) in enumerate(unbound, start=1))
     prompt = (
@@ -165,6 +171,52 @@ def _retry_src_bindings(unbound: list[tuple[int, str]], source_text: str,
         if 1 <= k <= len(unbound) and val != "none" and int(val) in turn_ids:
             repairs[unbound[k - 1][0]] = int(val)
     return repairs
+
+
+def _repair_binding_refused(fact: str, cand: dict, new_msgs: list[dict],
+                            allow: set[str]) -> str | None:
+    """Check a src= binding the miner supplied on the #35 corrective RETRY
+    against the turn it names. None = honour the binding; a short phrase = the
+    reason it was refused (the fact then stays unbound and the existing
+    fail-safe holds it).
+
+    Why only the retry's bindings: the first pass answers with the whole
+    excerpt in front of it, and its bindings are judged exactly as they always
+    have been. The retry is a second, narrower guess made after the miner
+    already failed to point at a source once — and in a guest-present window
+    that guess decides ATTRIBUTION. A retry that answers with the owner's turn
+    for a sentence a guest actually said converts guest speech into canon at
+    high confidence, and nothing downstream would notice: the grounding wall
+    reads the whole chunk (a guest's words ARE in the chunk), and the speaker
+    trust flag reads the bound turn, which is now the owner's.
+
+    So the binding has to survive two deterministic checks, both fail-safe:
+
+      1. the named turn must share at least one distinctive content word with
+         the fact — a turn that has none of its wording did not state it;
+      2. no OTHER speaker's turn in the window whose speech is untrusted (a
+         guest, an unidentified voice, an unrecognised class) may match the
+         fact's wording as well as, or better than, the named turn. A tie is
+         refused on purpose: "these words look at least as much like Sam's" is
+         precisely the case where attributing them to the owner is a guess.
+
+    Refusing costs a review-queue row; accepting a wrong binding costs a false
+    fact about the owner that reads as if he said it. This is the direction
+    that error should fall.
+    """
+    if cand is None:     # belt and braces: the caller already filters to real
+        return "it named no turn in this window"   # turns in this window
+    support = walls.lexical_support(fact, _msg_body(cand), allow)
+    if support == 0:
+        return "the turn it named shares none of this fact's wording"
+    rival = max((walls.lexical_support(fact, _msg_body(m), allow)
+                 for m in new_msgs
+                 if m["id"] != cand["id"] and walls.speaker_trust_flag(m["speaker"])),
+                default=0)
+    if rival >= support:
+        return ("another speaker's turn in this window matches this fact's "
+                "wording at least as closely as the turn it named")
+    return None
 
 # A long-idle conversation (e.g. an imported backlog) can hold more transcript
 # than the utility model's context window — mine in bounded windows, advancing
@@ -545,12 +597,19 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         # that happens to sit in that turn could still borrow onto an unrelated
         # fact — a narrower re-opening of the exact #33 hole.
         bound = idx_to_msg.get(int(src.group(1))) if src else None
+        repair_refused = None
         if bound is None and line_no in src_repairs:
             # #35: the corrective retry supplied the binding the first pass
-            # omitted or mis-numbered. From here the fact behaves exactly as
-            # if it had arrived bound: speaker trust, event-date grounding,
-            # and the recorded source message all read from this turn.
-            bound = idx_to_msg.get(src_repairs[line_no])
+            # omitted or mis-numbered — but only after it survives
+            # _repair_binding_refused does the fact behave as if it had
+            # arrived bound (speaker trust, event-date grounding, and the
+            # recorded source message all read from this turn). A refused
+            # repair leaves the fact unbound, exactly as if the retry had
+            # answered src=none, so the fail-safe below still holds it.
+            cand = idx_to_msg.get(src_repairs[line_no])
+            repair_refused = _repair_binding_refused(fact, cand, new_msgs, allow)
+            if repair_refused is None:
+                bound = cand
         if bound is not None:
             conv_ts = bound["created_at"]
             event_date = _grounded_event_date(
@@ -560,7 +619,15 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         else:
             conv_ts = new_msgs[-1]["created_at"]
             event_date = conv_ts            # no binding → conversation time, full stop
-            source_message_id = new_msgs[-1]["id"]
+            # ...and NO source message. The window's last turn used to be
+            # recorded here as a stand-in, which read downstream (the admin
+            # page's "source message #N", any reviewer following the trail) as
+            # real provenance for a fact that was never tied to that turn — or
+            # to any turn. An unbound fact is stored unbound: the transcript
+            # still holds every word, and `conversation_id` still says which
+            # chat it came from, so nothing is lost except a claim we cannot
+            # support.
+            source_message_id = None
         # The walls (grounding/source-trust/scope) still read the whole chunk:
         # a fact may legitimately synthesise across turns, and #33 is about the
         # event date only — narrowing the walls here would be scope creep.
@@ -577,12 +644,22 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         # has, because every human turn is the owner's.
         if bound is not None:
             speaker_flag = walls.speaker_trust_flag(bound["speaker"])
+        elif not untrusted_speaker_present:
+            speaker_flag = None
+        elif repair_refused:
+            # The retry did answer, and the answer did not hold up against the
+            # turn it named. Same fail-safe hold, but the reason says which of
+            # the two failures happened, so the reviewer knows whether the
+            # miner never pointed anywhere or pointed somewhere unsupported.
+            speaker_flag = (
+                "speaker-trust: the src= binding supplied on retry does not "
+                f"hold up — {repair_refused} — so this fact cannot be "
+                "attributed to the owner")
         else:
             speaker_flag = (
                 "speaker-trust: no valid src= binding, and none supplied on "
                 "retry, in a session with guest or unrecognised speakers — "
-                "cannot attribute this fact to the owner"
-            ) if untrusted_speaker_present else None
+                "cannot attribute this fact to the owner")
         if speaker_flag:
             flags = flags + [speaker_flag]
         if importance is None:

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -231,6 +231,14 @@
                      margin: var(--space-2) 0 var(--space-3);
                      font-variant-numeric: tabular-nums; }
   .reason { color: var(--warn); font-size: 12px; line-height: 16px; margin-top: var(--space-2); }
+  /* the turn a held fact came from — the evidence you judge it against */
+  .src-turn { border-left: 2px solid var(--border); padding-left: var(--space-3);
+              margin-top: var(--space-3); font-size: 13px; line-height: 20px;
+              max-width: 68ch; }
+  .src-turn .who { color: var(--dim); font-size: 12px; line-height: 16px; }
+  .src-turn .said { color: var(--fg); white-space: pre-wrap; word-wrap: break-word; }
+  .src-turn.unbound { border-left-color: var(--warn); }
+  .src-turn.unbound .who { color: var(--warn); }
   .muted { color: var(--dim); }
   .empty { color: var(--dim); font-style: italic; padding: var(--space-3) 0; }
   .empty.good { color: var(--ok); font-style: normal; }
@@ -783,6 +791,29 @@ function renderSel() {
   });
 }
 
+// Who spoke the turn a held fact came from. The owner is "you"; a guest is
+// named; an unidentified voice says so. Anything else renders verbatim rather
+// than being guessed at.
+function speakerLabel(s) {
+  if (s.speaker_class === "owner") return "you";
+  if (s.speaker_class === "guest") return s.speaker.split(":").slice(1).join(":").trim() + " (guest)";
+  if (s.speaker_class === "guest-unknown") return "an unidentified speaker (guest)";
+  return s.speaker;
+}
+
+// The evidence block on a review card. A fact with a real source turn shows
+// who said it and what they said; a fact with none says exactly that, because
+// "we don't know who said this" is the thing worth knowing before approving.
+function sourceTurn(f) {
+  if (!f.source)
+    return `<div class="src-turn unbound"><div class="who">⚑ Unbound — no source turn recorded.
+      This fact was never tied to a single message${f.conversation_id == null ? "" : `; conversation #${f.conversation_id}`}.</div></div>`;
+  const s = f.source;
+  return `<div class="src-turn">
+    <div class="who">Said by <b>${esc(speakerLabel(s))}</b> · message #${s.message_id} · ${fmtWhen(s.created_at)}</div>
+    <div class="said">${esc(s.excerpt)}${s.truncated ? " …" : ""}</div></div>`;
+}
+
 async function loadReview() {
   let facts;
   try { ({ facts } = await api("/review")); }
@@ -799,6 +830,7 @@ async function loadReview() {
     <div class="fact-card" id="review-card-${f.id}">
       <div class="fact-text">${esc(f.content)}</div>
       <div class="reason">⚠ ${esc(f.quarantine_reason || "quarantined")}</div>
+      ${sourceTurn(f)}
       <div class="meta">#${f.id} · origin <b>${esc(f.origin_agent)}</b> ·
         event ${fmtDate(f.event_date)} · created ${fmtWhen(f.created_at)} ·
         confidence ${esc(f.confidence)}</div>
@@ -965,7 +997,10 @@ function provRows(f) {
     ["created", fmtWhen(f.created_at)], ["event date", fmtDate(f.event_date)],
     ["confidence", f.confidence],
     ["conversation", f.conversation_id == null ? "—" : "#" + f.conversation_id],
-    ["source message", f.source_message_id == null ? "—" : "#" + f.source_message_id],
+    // A mined fact with no source message wasn't tied to one turn — say so,
+    // rather than leaving a dash that reads like missing data.
+    ["source message", f.source_message_id != null ? "#" + f.source_message_id
+      : f.source === "chat" ? "— unbound (no single source turn)" : "—"],
   ];
   if (f.invalidated_at) rows.push(["superseded", `${fmtWhen(f.invalidated_at)} → #${f.superseded_by}`]);
   if (f.quarantined_at) rows.push(["quarantined", fmtWhen(f.quarantined_at)],

--- a/memory_service/walls.py
+++ b/memory_service/walls.py
@@ -36,6 +36,12 @@ the same way (fail safe), so a newer client can never mint trust by inventing
 a class. The owner's own `user` turns and the model seats are unchanged.
 These checks live here beside the other walls; the mining pass supplies the
 per-fact speaker binding, so `check()` below is unchanged.
+
+`lexical_support` is not a wall and never quarantines anything by itself. It
+is the deterministic word-overlap primitive the mining pass uses to check a
+src= binding the miner supplied on a CORRECTIVE RETRY, so an unverifiable
+guess about who spoke cannot quietly turn a guest's words into the owner's
+canon. It only ever fails toward the existing hold.
 """
 
 import re
@@ -329,6 +335,62 @@ def speaker_trust_flag(speaker: str) -> str | None:
                 "not attribute this turn confidently)")
     return (f"speaker-trust: unrecognised speaker class {speaker!r}, "
             "treated as untrusted")
+
+
+# ── lexical support (used to verify a retry-supplied src= binding) ───────────
+#
+# Function words carry no attribution signal: they appear in nearly every turn,
+# so counting them as "support" would let an unrelated turn look like a fact's
+# source. Only words of four or more characters are considered at all, which
+# already removes most of English's connective tissue; this list is the common
+# remainder plus the vague verbs a paraphrase reaches for.
+_SUPPORT_STOPWORDS = {
+    "about", "actually", "after", "again", "also", "another", "anything",
+    "back", "basically", "because", "been", "before", "being", "both", "came",
+    "come", "could", "days", "does", "doing", "done", "down", "during", "each",
+    "else", "even", "evening", "ever", "every", "everything", "from", "gets",
+    "give", "goes", "going", "gone", "have", "having", "here", "hour", "hours",
+    "into", "just", "keep", "kind", "know", "later", "like", "look", "made",
+    "make", "many", "maybe", "might", "month", "months", "more", "morning",
+    "most", "much", "must", "need", "next", "night", "okay", "over",
+    "probably", "really", "said", "same", "says", "should", "since", "some",
+    "someone", "something", "still", "stuff", "such", "sure", "take", "than",
+    "that", "them", "then", "there", "these", "they", "thing", "things",
+    "think", "this", "those", "through", "time", "today", "tonight",
+    "tomorrow", "under", "very", "want", "week", "weeks", "well", "went",
+    "were", "what", "when", "where", "which", "while", "will", "with",
+    "would", "year", "years", "yeah", "yesterday", "your",
+}
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def support_tokens(text: str, allowlist: set[str]) -> set[str]:
+    """The distinctive content words of `text`: lower-case, four characters or
+    more, minus function words and anything on the caller's allowlist (which
+    carries the owner's own name and their everyday nouns — words that recur in
+    every fact and would flatten the comparison below). Allowlist entries are
+    split into words too, so a two-word name excludes both of its parts."""
+    allowed = {w for entry in allowlist for w in _WORD_RE.findall(entry.lower())}
+    return {t for t in _WORD_RE.findall((text or "").lower())
+            if len(t) >= 4 and t not in _SUPPORT_STOPWORDS and t not in allowed}
+
+
+def lexical_support(fact: str, source_text: str, allowlist: set[str]) -> int:
+    """How many of `fact`'s distinctive content words `source_text` actually
+    contains — a coarse "did this wording come from here" signal.
+
+    Deliberately NOT a truth test and never used as one. Its single job is to
+    sanity-check a src= binding the miner supplied on a corrective retry (#35),
+    where the alternative is trusting an unverifiable guess about WHO SPOKE.
+    Exact word matches only: no stemming, no synonyms, no fuzzy matching, so a
+    heavy paraphrase scores low. That bias is the right way round, because the
+    only thing a low score can do in `mining` is HOLD a fact for review — it can
+    never drop one, and it can never grant trust a wall would otherwise refuse.
+    """
+    f = support_tokens(fact, allowlist)
+    if not f:
+        return 0
+    return len(f & support_tokens(source_text, allowlist))
 
 
 def is_system_meta(fact: str) -> bool:

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -123,6 +123,79 @@ def test_quarantine_accepted_facts_over_http(client):
     assert client.post(f"/v1/facts/{ids[0]}/approve").json()["quarantined_at"] is None
 
 
+# ── review evidence: the turn a held fact came from ────────────────────────
+#
+# A reviewer's first question is "who said this", and the queue could not
+# answer it. `source` answers it — and answers "nobody knows" honestly, rather
+# than pointing at a turn that merely sat nearby.
+
+
+def _room(con, settings, msgs, conv="room-r"):
+    from memory_service import episodic
+    episodic.ingest(con, "multi-model-chat", conv, [
+        {"external_id": f"m{i}", "speaker": sp, "content": text,
+         "created_at": 1700000000.0 + i * 60}
+        for i, (sp, text) in enumerate(msgs, start=1)], title="Kitchen chat")
+    return conv
+
+
+def test_review_row_carries_its_source_turn(client, con, settings, fake_llm):
+    from memory_service import mining
+    _room(con, settings, [
+        ("user", "Dinner planning time."),
+        ("guest:Sam", "I hate coriander, please leave it out of everything."),
+    ])
+    fake_llm["response"] = (
+        "NEW src=2 importance=4: Alex's wife Sam dislikes coriander.")
+    mining.distill(con, settings, "multi-model-chat", "room-r", regenerate=False)
+
+    row = client.get("/v1/review").json()["facts"][0]
+    src = row["source"]
+    assert src["message_id"] == row["source_message_id"]
+    assert src["speaker"] == "guest:Sam" and src["speaker_class"] == "guest"
+    assert "coriander" in src["excerpt"] and src["truncated"] is False
+
+
+def test_review_row_for_an_unbound_fact_names_no_turn(client, con, settings,
+                                                      fake_llm):
+    from memory_service import mining
+    _room(con, settings, [
+        ("user", "We are planning this week's meals."),
+        ("guest:Sam", "I hate coriander."),
+    ], conv="room-u")
+    # No src= anywhere, and the retry (fed the same canned answer) supplies
+    # none either — the fact is held, unattributed.
+    fake_llm["response"] = "NEW importance=4: Alex's wife Sam dislikes coriander."
+    mining.distill(con, settings, "multi-model-chat", "room-u", regenerate=False)
+
+    row = client.get("/v1/review").json()["facts"][0]
+    assert row["source_message_id"] is None
+    assert row["source"] is None        # no turn invented to fill the gap
+
+
+def test_review_source_excerpt_is_bounded(client, con, settings, fake_llm):
+    from memory_service import api, mining
+    long_turn = "I hate coriander. " + "We talked about the menu. " * 200
+    _room(con, settings, [("user", "Dinner planning time."),
+                          ("guest:Sam", long_turn)], conv="room-l")
+    fake_llm["response"] = (
+        "NEW src=2 importance=4: Alex's wife Sam dislikes coriander.")
+    mining.distill(con, settings, "multi-model-chat", "room-l", regenerate=False)
+
+    src = client.get("/v1/review").json()["facts"][0]["source"]
+    assert len(src["excerpt"]) == api.REVIEW_EXCERPT_CHARS
+    assert src["truncated"] is True     # and it says so, rather than eliding
+
+
+def test_review_row_without_any_source_message_is_unbound_too(client):
+    # Not every held fact comes from mining: an external MCP write has no turn
+    # at all. Same honest answer, no crash reaching for a message row.
+    client.post("/v1/facts", json={"content": "Alex is allergic to shellfish.",
+                                   "origin_agent": "mcp:claude-code"})
+    row = client.get("/v1/review").json()["facts"][0]
+    assert row["source"] is None
+
+
 def test_recall_and_summary_endpoints(client, fake_llm):
     client.post("/v1/facts", json={"content": "Alex trains for a triathlon."})
     hits = client.post("/v1/recall", json={"query": "triathlon"}).json()["facts"]

--- a/tests/test_guest_speakers.py
+++ b/tests/test_guest_speakers.py
@@ -329,6 +329,130 @@ def test_no_src_retry_in_owner_only_window(con, settings, fake_llm,
     assert len(fake_llm["prompts"]) == 1
 
 
+# ── a retry binding is verified against the turn it names ───────────────────
+
+
+def test_retry_binding_to_a_turn_that_never_said_it_is_refused(
+        con, settings, fake_llm):
+    # THE unsafe path: the retry answers with the OWNER's turn for a sentence
+    # the guest actually said. Nothing downstream would catch it — the
+    # grounding wall reads the whole chunk (the guest's words are in it) and
+    # the speaker check reads the bound turn, which is now the owner's — so
+    # the fact would land as canon, high confidence, in Alex's own voice.
+    # The named turn shares none of the fact's wording, so the binding is
+    # refused and the fail-safe hold stands.
+    _ingest(con, [
+        ("user", "Dinner planning time."),
+        ("guest:Sam", "I hate coriander, please leave it out of everything."),
+    ])
+    fake_llm["queue"] = [
+        "NEW importance=4: Alex's wife Sam dislikes coriander.",
+        "FACT 1: src=1",
+    ]
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}
+    assert ledger.list_facts(con, status="valid") == []
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert "src=" in held["quarantine_reason"]
+    assert "retry" in held["quarantine_reason"]
+    # ...and the refusal is stated as itself, not as "the miner never answered"
+    assert "none of this fact's wording" in held["quarantine_reason"]
+
+
+def test_retry_binding_refused_when_a_guest_turn_matches_as_well(
+        con, settings, fake_llm):
+    # The owner's turn does share a word with the fact — but so does the
+    # guest's, just as strongly. "These words look at least as much like Sam's"
+    # is exactly the case where attributing them to Alex is a guess, so a tie
+    # holds rather than trusts.
+    _ingest(con, [
+        ("user", "Should we do the coriander salad again?"),
+        ("guest:Sam", "I hate coriander."),
+    ])
+    fake_llm["queue"] = [
+        "NEW importance=4: Alex's wife Sam dislikes coriander.",
+        "FACT 1: src=1",
+    ]
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 1}
+    assert ledger.list_facts(con, status="valid") == []
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert "at least as closely" in held["quarantine_reason"]
+
+
+def test_verification_does_not_hold_a_genuinely_supported_binding(
+        con, settings, fake_llm):
+    # The check must not undo #35: a retry that names the turn the fact plainly
+    # came from still lands as canon, so an omitted src= tag costs nothing.
+    # (test_src_retry_binds_owner_fact_to_owner_turn is the same guarantee from
+    # the other side; this one pins that verification is what let it through.)
+    _ingest(con, [
+        ("user", "I have signed up for the Fairhaven half marathon."),
+        ("guest:Sam", "I will cheer from the finish line."),
+    ])
+    fake_llm["queue"] = [
+        "NEW importance=5: Alex signed up for the Fairhaven half marathon.",
+        "FACT 1: src=1",
+    ]
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 0}
+    valid = ledger.list_facts(con, status="valid")
+    assert len(valid) == 1
+    first = episodic.messages_after(
+        con, episodic.get_conversation(con, "multi-model-chat", "room-1")["id"], 0)[0]
+    assert valid[0]["source_message_id"] == first["id"]
+
+
+def test_first_pass_bindings_are_not_re_judged(con, settings, fake_llm):
+    # Scope: verification applies to the RETRY's second guess, not to the first
+    # pass, which answers with the whole excerpt in front of it. A first-pass
+    # binding behaves exactly as it always has — no extra call, no new hold.
+    _ingest(con, [
+        ("user", "Dinner planning time."),
+        ("guest:Sam", "I hate coriander."),
+    ])
+    fake_llm["response"] = (
+        "NEW src=1 importance=4: Alex is organising the meals this fortnight.")
+    res = mining.distill(con, settings, "multi-model-chat", "room-1",
+                         regenerate=False)
+    assert res == {"added": 1, "quarantined": 0}
+    assert len(fake_llm["prompts"]) == 1
+
+
+# ── an unbound fact is stored unbound ───────────────────────────────────────
+
+
+def test_unbound_fact_records_no_source_message(con, settings, fake_llm):
+    # The window's last turn used to be stored as the source message of a fact
+    # that was never tied to any turn, which reads downstream as real
+    # provenance ("source message #N"). An unbound fact now records none.
+    _ingest(con, [
+        ("user", "We are planning this week's meals."),
+        ("guest:Sam", "I hate coriander."),
+    ])
+    fake_llm["response"] = "NEW importance=4: Alex's wife Sam dislikes coriander."
+    mining.distill(con, settings, "multi-model-chat", "room-1", regenerate=False)
+    held = ledger.list_facts(con, status="quarantined")[0]
+    assert held["source_message_id"] is None
+    # The chat it came from is still recorded — the trail is narrowed, not lost.
+    conv = episodic.get_conversation(con, "multi-model-chat", "room-1")
+    assert held["conversation_id"] == conv["id"]
+
+
+def test_unbound_owner_only_fact_is_still_valid_but_unbound(
+        con, settings, fake_llm, sample_conversation):
+    # Trust is untouched by this change: an unbound fact in an owner-only
+    # window is canon exactly as before. Only the fabricated provenance goes.
+    fake_llm["response"] = "NEW importance=5: Alex moved to Springfield."
+    mining.distill(con, settings, "multi-model-chat", "chat-1", regenerate=False)
+    fact = ledger.list_facts(con, status="valid")[0]
+    assert fact["source_message_id"] is None
+    assert fact["quarantine_reason"] is None
+
+
 # ── ingest accepts the new class (additive contract) ────────────────────────
 
 

--- a/tests/test_walls.py
+++ b/tests/test_walls.py
@@ -144,3 +144,32 @@ def test_temporal_and_entity_flags_are_reported_separately():
     flags = walls.check("Alex meets Shelbyville Corp tomorrow.", SCHEDULE, set())
     assert any("grounding" in f and "Shelbyville" in f for f in flags)
     assert any("temporal" in f and "tomorrow" in f for f in flags)
+
+
+# ── lexical support: the primitive behind retry-binding verification ─────────
+
+
+def test_lexical_support_counts_shared_distinctive_words():
+    fact = "Alex signed up for the Fairhaven half marathon."
+    assert walls.lexical_support(
+        fact, "I have signed up for the Fairhaven half marathon.", {"alex"}) > 0
+    # An unrelated turn shares none of the fact's distinctive wording.
+    assert walls.lexical_support(fact, "Dinner planning time.", {"alex"}) == 0
+
+
+def test_lexical_support_ignores_function_words_and_the_allowlist():
+    # "will/have/that/thing/this" recur in every turn: counting them would make
+    # any turn look like any fact's source. The owner's own name is on the
+    # allowlist for the same reason — it is in nearly every fact.
+    assert walls.lexical_support(
+        "Alex will have that thing this week.",
+        "I will have that thing this week too.", {"alex"}) == 0
+
+
+def test_lexical_support_measures_wording_not_who_spoke():
+    # It scores WORDING only, so a guest's turn scores for a fact drawn from it
+    # exactly as the owner's would — which is what makes comparing the turns of
+    # a window a usable attribution signal in mining.
+    fact = "Alex's wife Sam dislikes coriander."
+    assert walls.lexical_support(fact, "I hate coriander.", {"alex"}) == 1
+    assert walls.lexical_support(fact, "Sam dislikes coriander.", {"alex"}) == 2


### PR DESCRIPTION
## What & why

Three tightly-scoped fixes on the guest-session mining path, all pointing the same
way: **never claim provenance the pass cannot support.** Investigated read-only
first; this is the smallest safe slice of that, deliberately excluding the
metrics/dashboard/grouping ideas. Follows #35; context for the review-queue pain is
#40 and #34 (neither closed by this).

**1. An unbound fact is stored unbound.** When the miner could not tie a fact to a
single turn, `mining` wrote *the window's last message* into `source_message_id`.
Downstream that reads as real provenance (the admin page prints "source message
#N", and a reviewer following the trail lands on a turn that never said it).
It is now `NULL`. `conversation_id` still records which chat it came from, and the
transcript still holds every word — only the unsupportable claim goes.

**2. The review queue carries its evidence.** `GET /review` rows gain an additive
`source` object — speaker, speaker class, message id, bounded 400-char excerpt —
and the admin card renders it, so "who said this?" is answerable without leaving
the queue. `source` is `null` whenever no real source message exists (unbound
mined fact, `mcp:*` write, hand-saved fact); a nearby turn is never dressed up as
the origin. *"Sam said this"* and *"nobody knows who said this"* are different
decisions and the queue must not blur them.

**3. A retry-supplied `src=` binding is verified against the turn it names.** This
is the actual unsafe path. The #35 corrective retry was an unverified guess about
**who spoke**: an answer naming the owner's turn for a sentence a guest actually
said landed as canon at high confidence, and nothing downstream could catch it —
the grounding wall reads the whole chunk (the guest's words *are* in the chunk)
and the speaker-trust flag reads the bound turn, which is now the owner's. A
retry's binding must now:

1. share at least one distinctive content word with the fact (`walls.lexical_support`), and
2. be at least as plausible as every *untrusted* speaker's turn in the same window —
   ties are refused, because "these words look at least as much like Sam's" is
   precisely where attributing them to the owner is a guess.

A refusal leaves the fact unbound, so the **existing** fail-safe hold applies, with
the reason naming which failure happened. First-pass bindings are untouched: they
are answered with the whole excerpt in view, and re-judging them was out of scope.

### What did NOT change

- Trust policy. Nothing that quarantined before is trusted now; nothing new is
  dropped. A refused binding can only ever **hold** a fact for review.
- The fail-safe hold itself, the walls, the drop filters, dating and supersession.
- No schema change/migration, no new endpoint, no metrics or dashboard surface.
- `lexical_support` is exact-match only (no stemming/synonyms), so a heavy
  paraphrase scores low — the bias falls toward holding, which is the safe side.
  If it proves noisy in practice, the fix is evidence (counting hold reasons), not
  a looser threshold.

### Tests

`tests/test_walls.py` — the support primitive (shared distinctive words; function
words and allowlist ignored; wording-not-speaker).
`tests/test_guest_speakers.py` — retry naming a turn that never said it is refused;
a tie with a guest's turn is refused; a genuinely supported retry still lands as
canon (so #35 is not undone); first-pass bindings are not re-judged; unbound facts
record no source message, in both guest and owner-only windows.
`tests/test_api_contract.py` — `/review` carries the source turn for a bound fact,
says nothing for an unbound one, bounds the excerpt, and handles a fact with no
source message at all.

## Checklist

- [x] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q` → **396 passed**
- [x] No real personal data anywhere in the diff. Synthetic roster only (Alex, wife Sam, Fairhaven, Springfield). *Note: the sandbox could not execute `scripts/secret-scan.sh`, so the diff was reviewed by eye against the roster rather than scanned.*
- [x] The invariants still hold (append-only; episodic record immutable; quarantine honored; `tests/test_invariants.py` green)
- [x] CHANGELOG.md entry under Unreleased; `docs/API.md` and `docs/MEMORY_INTEGRITY.md` updated
- [x] New UI surface (the review card's source-turn block) states in plain words either who said it or that nothing is known

🤖 Generated with [Claude Code](https://claude.com/claude-code)
