### PR TITLE
Group the review queue by hold reason; one decision clears a cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- The review queue groups by hold reason, and one decision clears a
+  cause (#34). Every held fact carries a stable reason class (said by a
+  guest, couldn't prove who said it, external write, and so on); the
+  admin page shows the queue grouped by it, largest cause first, with
+  approve-all and dismiss-all per group acting on exactly the rows on
+  screen. Owner-only, like every review action - nothing automated can
+  approve anything.
+
 - Review evidence, and provenance only where it is real: a held fact now
   shows the turn it came from — who said it and what they said — in the
   review queue, on the admin page and in `GET /review`. A fact the miner

--- a/docs/API.md
+++ b/docs/API.md
@@ -445,6 +445,16 @@ reviewer has — who said this — is answered without leaving the queue.
            "created_at": 1754616000.0, "excerpt": "I hate coriander…",
            "truncated": false}
 ```
+Each row also carries `reason_class` (additive, 2026-08-14, #34): a stable
+token derived from the hold reason's prefix (`guest-attribution`,
+`speaker-trust`, `grounding`, `temporal`, `source-trust`, `importance`,
+`external-write`, else `other`; a multi-flag reason classes by its first
+flag). The admin page groups the queue by it, and
+`POST /facts/bulk-approve` / `POST /facts/bulk-dismiss` (owner credential,
+body `{"ids": [...]}`) act on explicit id lists - only ids currently in the
+queue are touched, everything else is skipped, not an error, so one decision
+clears a whole cause without ever sweeping rows the owner has not seen.
+
 `source` is `null` whenever the fact names no source message: an external
 (`mcp:*`) write, a fact saved by hand, or a mined fact that could not be tied
 to a single turn (see the guest-speaker notes above). It is never filled in

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -47,6 +47,7 @@ import datetime
 import hmac
 import json
 import os
+import re
 import secrets
 import stat
 from pathlib import Path
@@ -170,6 +171,22 @@ def _recall_out(f: dict) -> dict:
 # away in the episodic record for anyone who wants it.
 REVIEW_EXCERPT_CHARS = 400
 
+# The hold-reason CLASSES the review queue groups by (#34). Reasons are
+# free text with a stable "prefix:" convention (and multi-flag reasons join
+# with "; "); the class is the first flag's prefix, so one decision can
+# clear a whole cause. Kept additive: the full reason still rides each row.
+_REASON_PREFIX_RE = re.compile(r"^([a-z-]+):")
+
+
+def reason_class(reason) -> str:
+    head = (reason or "").split(";")[0].strip()
+    if not head:
+        return "other"
+    if head.startswith("external write"):
+        return "external-write"
+    m = _REASON_PREFIX_RE.match(head)
+    return m.group(1) if m else "other"
+
 
 def _review_out(c, f: dict) -> dict:
     """One review-queue row plus the turn it came from — speaker, speaker
@@ -184,6 +201,7 @@ def _review_out(c, f: dict) -> dict:
     who said this" are different decisions, and the queue must not blur them.
     """
     out = dict(f)
+    out["reason_class"] = reason_class(f.get("quarantine_reason"))
     row = None
     if f.get("source_message_id") is not None:
         row = c.execute(
@@ -1135,6 +1153,53 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
             if not ledger.dismiss(c, fact_id):
                 raise HTTPException(409, "fact missing or not quarantined")
             return ledger.get_fact(c, fact_id)
+        finally:
+            c.close()
+
+    class BulkIds(BaseModel):
+        ids: list[int]
+
+    def _pending_among(c, ids):
+        """Of these ids, the ones actually IN the review queue right now
+        (quarantined and not yet dismissed). The ledger primitives are
+        looser on purpose - approve un-quarantines anything, dismiss
+        re-stamps an already-dismissed row - but a BULK action's contract
+        is the queue, so anything else is skipped, not touched."""
+        if not ids:
+            return set()
+        marks = ",".join("?" * len(ids))
+        return {r[0] for r in c.execute(
+            f"SELECT id FROM facts WHERE id IN ({marks}) "
+            "AND quarantined_at IS NOT NULL AND review_dismissed_at IS NULL",
+            ids)}
+
+    @app.post("/v1/facts/bulk-approve", dependencies=[Depends(_admin_auth)])
+    def bulk_approve(body: BulkIds):
+        # #34: one decision clears a cause. Acts only on ids CURRENTLY in
+        # the queue; anything else is skipped, not an error, so a stale
+        # screen re-submits harmlessly. Owner-gated like every review
+        # action - the no-auto-approve invariant holds.
+        c = con()
+        try:
+            pending = _pending_among(c, body.ids)
+            done = sum(1 for i in body.ids
+                       if i in pending and ledger.approve(c, i))
+            return {"approved": done, "skipped": len(body.ids) - done}
+        finally:
+            c.close()
+
+    @app.post("/v1/facts/bulk-dismiss", dependencies=[Depends(_admin_auth)])
+    def bulk_dismiss(body: BulkIds):
+        # Bulk twin of the per-fact dismiss, by explicit ids (#34): the
+        # group the owner SAW is the group acted on - never "whatever
+        # matches the reason right now", which could sweep rows that
+        # arrived after the screen rendered.
+        c = con()
+        try:
+            pending = _pending_among(c, body.ids)
+            done = sum(1 for i in body.ids
+                       if i in pending and ledger.dismiss(c, i))
+            return {"dismissed": done, "skipped": len(body.ids) - done}
         finally:
             c.close()
 

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -240,6 +240,15 @@
   .src-turn.unbound { border-left-color: var(--warn); }
   .src-turn.unbound .who { color: var(--warn); }
   .muted { color: var(--dim); }
+  /* hold-reason groups (#34): one decision clears a cause */
+  .review-group { margin-bottom: var(--space-4); }
+  .review-group-head { display: flex; align-items: center; justify-content: space-between;
+                       gap: var(--space-3); padding: var(--space-2) 0;
+                       border-bottom: 1px solid var(--border);
+                       margin-bottom: var(--space-2); position: sticky; top: 0;
+                       background: var(--bg); z-index: 2; }
+  .review-group-title { font-weight: 600; }
+  .review-group-actions { display: flex; gap: var(--space-2); }
   .empty { color: var(--dim); font-style: italic; padding: var(--space-3) 0; }
   .empty.good { color: var(--ok); font-style: normal; }
   .err-panel {
@@ -814,19 +823,36 @@ function sourceTurn(f) {
     <div class="said">${esc(s.excerpt)}${s.truncated ? " …" : ""}</div></div>`;
 }
 
-async function loadReview() {
-  let facts;
-  try { ({ facts } = await api("/review")); }
-  catch (e) { errPanel("review-body", "Couldn't load the review queue: " + e.message, "loadReview"); return; }
-  REVIEW = facts; SEL = Math.min(SEL, Math.max(0, facts.length - 1));
-  setReviewCount(facts.length);
-  if (!facts.length) {
-    $("review-body").innerHTML = '<div class="empty good">Nothing to review ✓</div>';
-    return;
-  }
-  $("review-body").innerHTML =
-    '<div class="keys-hint"><kbd>j</kbd>/<kbd>k</kbd> navigate · <kbd>a</kbd> approve · <kbd>d</kbd> dismiss</div>' +
-    facts.map(f => `
+// Plain-English headings for the hold-reason classes (#34). Unknown
+// classes render their raw token rather than being guessed at.
+const REASON_CLASS_COPY = {
+  "guest-attribution": "Said by a guest",
+  "speaker-trust": "Couldn't prove who said it",
+  "grounding": "Not grounded in the transcript",
+  "temporal": "Uncertain when this happened",
+  "source-trust": "Untrusted source content",
+  "importance": "Low importance",
+  "external-write": "Written by external tooling",
+  "other": "Other holds",
+};
+
+function reasonHeading(cls) { return REASON_CLASS_COPY[cls] || cls; }
+
+// One decision clears a cause (#34): bulk act on exactly the ids the owner
+// is LOOKING at in this group - never "whatever matches the reason now".
+async function bulkReview(action, ids) {
+  const verb = action === "approve" ? "Approve" : "Dismiss";
+  if (!confirm(`${verb} all ${ids.length} facts in this group?`)) return;
+  try {
+    await api(`/facts/bulk-${action}`, { method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids }) });
+  } catch (e) { alert(`Bulk ${action} failed: ` + e.message); }
+  loadReview(); loadStats();
+}
+
+function reviewCard(f) {
+  return `
     <div class="fact-card" id="review-card-${f.id}">
       <div class="fact-text">${esc(f.content)}</div>
       <div class="reason">⚠ ${esc(f.quarantine_reason || "quarantined")}</div>
@@ -838,6 +864,41 @@ async function loadReview() {
         <button class="good" onclick="approveFact(${f.id})">Approve <kbd>a</kbd></button>
         <button class="bad" onclick="dismissFact(${f.id})">Dismiss <kbd>d</kbd></button>
       </div>
+    </div>`;
+}
+
+async function loadReview() {
+  let facts;
+  try { ({ facts } = await api("/review")); }
+  catch (e) { errPanel("review-body", "Couldn't load the review queue: " + e.message, "loadReview"); return; }
+  REVIEW = facts; SEL = Math.min(SEL, Math.max(0, facts.length - 1));
+  setReviewCount(facts.length);
+  if (!facts.length) {
+    $("review-body").innerHTML = '<div class="empty good">Nothing to review ✓</div>';
+    return;
+  }
+  // Group by hold-reason class (#34), groups ordered largest first so the
+  // one decision that clears the most is always at the top.
+  const groups = new Map();
+  for (const f of facts) {
+    const cls = f.reason_class || "other";
+    if (!groups.has(cls)) groups.set(cls, []);
+    groups.get(cls).push(f);
+  }
+  const ordered = [...groups.entries()].sort((a, b) => b[1].length - a[1].length);
+  $("review-body").innerHTML =
+    '<div class="keys-hint"><kbd>j</kbd>/<kbd>k</kbd> navigate · <kbd>a</kbd> approve · <kbd>d</kbd> dismiss</div>' +
+    ordered.map(([cls, rows]) => `
+    <div class="review-group">
+      <div class="review-group-head">
+        <span class="review-group-title">${esc(reasonHeading(cls))}
+          <span class="muted">· ${rows.length}</span></span>
+        <span class="review-group-actions">
+          <button class="good" onclick='bulkReview("approve", ${JSON.stringify(rows.map(r => r.id))})'>Approve all ${rows.length}</button>
+          <button class="bad" onclick='bulkReview("dismiss", ${JSON.stringify(rows.map(r => r.id))})'>Dismiss all ${rows.length}</button>
+        </span>
+      </div>
+      ${rows.map(reviewCard).join("")}
     </div>`).join("");
   renderSel();
 }

--- a/tests/test_review_grouping.py
+++ b/tests/test_review_grouping.py
@@ -1,0 +1,93 @@
+"""The review queue grouped by hold reason, with bulk actions (#34).
+
+The owner's complaint, twice on the record: a big pending queue where every
+row needs an individual decision, even when forty rows are held for the same
+cause. The contract under test:
+
+- every /review row carries a stable reason_class derived from the reason's
+  prefix convention (first flag wins for multi-flag reasons; external writes
+  class as external-write; anything unrecognised is other, never a guess);
+- bulk approve/dismiss act on explicit ids, owner-gated, skipping anything
+  not currently pending rather than erroring - so a stale screen re-submits
+  harmlessly and no automated path can approve anything (the invariant).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import api as api_mod
+from memory_service.api import reason_class
+
+
+def test_reason_class_truth_table():
+    assert reason_class("guest-attribution: stated by guest Sam, held") == "guest-attribution"
+    assert reason_class("speaker-trust: no valid src= binding") == "speaker-trust"
+    assert reason_class("grounding: not supported by the excerpt") == "grounding"
+    # multi-flag reasons: the first flag is the class
+    assert reason_class("speaker-trust: x; grounding: y — review before trusting") == "speaker-trust"
+    assert reason_class("external write (mcp:tool) — held for review") == "external-write"
+    assert reason_class("free-text with no prefix at all") == "other"
+    assert reason_class("") == "other"
+    assert reason_class(None) == "other"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMORY_DATA_DIR", str(tmp_path / "data"))
+    app = api_mod.create_app()
+    with TestClient(app, base_url="http://127.0.0.1") as c:
+        c.app = app
+        yield c
+
+
+def _admin(c):
+    return {"Authorization": f"Bearer {c.app.state.admin_token}"}
+
+
+def _hold_fact(c, content, reason):
+    """Seed a held fact the way the MINER does - through the ledger with an
+    explicit reason - because the public /facts API deliberately assigns its
+    own untrusted-origin reason and would flatten every class to
+    external-write."""
+    from memory_service import db as mdb, ledger
+    con = mdb.connect(c.app.state.settings.db_path)
+    try:
+        row = ledger.add_fact(con, content, c.app.state.settings,
+                              origin_agent="miner-test",
+                              quarantine_reason=reason)
+        return row["id"]
+    finally:
+        con.close()
+
+
+def test_review_rows_carry_reason_class(client):
+    _hold_fact(client, "guest fact one here", "guest-attribution: stated by guest Sam")
+    _hold_fact(client, "unbound fact two here", "speaker-trust: no valid src= binding")
+    rows = client.get("/v1/review", headers=_admin(client)).json()["facts"]
+    classes = sorted(r["reason_class"] for r in rows)
+    assert classes == ["guest-attribution", "speaker-trust"]
+
+
+def test_bulk_approve_and_dismiss_by_explicit_ids(client):
+    a = _hold_fact(client, "held fact aaa content", "guest-attribution: stated by guest Sam")
+    b = _hold_fact(client, "held fact bbb content", "guest-attribution: stated by guest Sam")
+    d = _hold_fact(client, "held fact ddd content", "speaker-trust: no valid src= binding")
+
+    r = client.post("/v1/facts/bulk-approve", headers=_admin(client),
+                    json={"ids": [a, b, 999999]})
+    assert r.json() == {"approved": 2, "skipped": 1}
+    r = client.post("/v1/facts/bulk-dismiss", headers=_admin(client),
+                    json={"ids": [d, a]})          # a is no longer pending
+    assert r.json() == {"dismissed": 1, "skipped": 1}
+    assert client.get("/v1/review", headers=_admin(client)).json()["facts"] == []
+    # re-submitting the same ids is a harmless no-op, not an error
+    r = client.post("/v1/facts/bulk-dismiss", headers=_admin(client),
+                    json={"ids": [a, b, d]})
+    assert r.status_code == 200 and r.json()["dismissed"] == 0
+
+
+def test_bulk_endpoints_are_owner_gated(client):
+    assert client.post("/v1/facts/bulk-approve",
+                       json={"ids": [1]}).status_code in (401, 403)
+    assert client.post("/v1/facts/bulk-dismiss",
+                       json={"ids": [1]}).status_code in (401, 403)


### PR DESCRIPTION
Fixes #34. reason_class on every /review row (additive), grouped admin page with per-group bulk approve/dismiss by explicit ids (pending-only, skip-not-error, owner-gated). Full suite 400 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)