### PR TITLE
The owner can erase one archived message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- The owner can erase one archived message (#45), finishing what
+  crossband's discard starts: a voice turn deleted at the source may
+  already have a copy here, and nothing automated may touch it. The
+  danger zone gains a third eraser (and producers can deep-link it
+  prefilled, with a preview and the blast radius shown before you type
+  DELETE). Facts mined from the erased message move to review instead
+  of vanishing; attached files stay for their own eraser. Every human
+  erasure now leaves a content-free journal row: what was erased is
+  gone, that it was erased is not.
+
 - The review queue groups by hold reason, and one decision clears a
   cause (#34). Every held fact carries a stable reason class (said by a
   guest, couldn't prove who said it, external write, and so on); the

--- a/docs/API.md
+++ b/docs/API.md
@@ -431,8 +431,10 @@ appear in `GET /review`; each is reversible with `/facts/{id}/approve`. This is
 the third treatment between `supersede` (asserts a replacement fact, which a
 malformed row does not have) and `DELETE` (destructive). **Requires the owner
 admin token, even on loopback.**
-`DELETE /facts/{id}`: the ONLY hard delete; human-initiated only, never automated.
-**Requires the owner admin token, even on loopback.**
+`DELETE /facts/{id}`: one of the three human erasers (facts / attachments /
+messages); human-initiated only, never automated. Every erasure appends a
+content-free row (kind, refs, when - never content) to the `erasures` journal
+(#45). **Requires the owner admin token, even on loopback.**
 
 `GET /review`: held-for-review queue. **Requires the owner admin token, even
 on loopback.**
@@ -608,7 +610,27 @@ image/binary kind), the message it arrived with, and the ledger facts mined
 from that conversation.
 `DELETE /v1/attachments/{id}`: the attachments twin of the facts eraser:
 human-initiated via the danger zone, the only delete path; content-addressed
-bytes are unlinked only when no other row references them.
+bytes are unlinked only when no other row references them. Journals to
+`erasures` like every eraser.
+
+`GET /v1/messages/resolve?source_app=&conversation=&message=`: maps a
+producer's ref (how crossband names a message: source app, conversation
+external id, message external id) to the internal row id, with a verbatim
+preview and the erase's blast radius (live facts that would move to review,
+attached files that would stay). Exists so a producer's erase link can land
+on the admin page prefilled; the admin page reads
+`#erase=<source_app>/<conversation>/<message>` and calls this. **Requires
+the owner admin token, even on loopback.**
+
+`DELETE /v1/messages/{id}`: the messages twin of the facts eraser (#45),
+closing the crossband#106 loop - a voice turn discarded at its source may
+already be ingested here, and no automated path may touch the copy; this is
+the human hand. One row, no bulk form, never called by any producer's code.
+The row leaves the archive and the search index; live facts mined from it
+quarantine with a `source-deleted:` reason and surface in review (the owner
+decides each - derived knowledge never silently vanishes); attachments that
+rode the message are counted in the response, never cascaded. Journals to
+`erasures`. **Requires the owner admin token, even on loopback.**
 The three summary-version routes below, unlike the attachment routes above,
 are **NOT** gated: they answer an unauthenticated loopback caller.
 `GET /v1/summary/versions`: every generated profile, newest first (metadata

--- a/docs/MEMORY_INTEGRITY.md
+++ b/docs/MEMORY_INTEGRITY.md
@@ -91,7 +91,12 @@ walls make the *write* safe instead. This trade-off is deliberate.
 - Append-only: no automated path deletes a fact (supersede / quarantine / dismiss
   only; the sole hard delete is a human pressing the button).
 - The episodic transcript is ground truth and is never modified by any pass, which is
-  what makes a bad card *detectable* and traceable to its source.
+  what makes a bad card *detectable* and traceable to its source. The one exception
+  is the same human hand: the owner can erase a single archived message
+  (`DELETE /v1/messages/{id}`, #45 - the other half of crossband#106's discard).
+  Facts mined from it move to review rather than vanishing, and every erasure
+  (fact, file, or message) leaves a content-free row in the `erasures` journal:
+  what was erased is gone, that it was erased is not.
 - External writes (any MCP client) are quarantined at creation regardless of what
   they claim to be; the same "constrain the write" principle applied to authorship.
 - A mined fact's **event date** (the date the fact is *about*) is only honoured when

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,7 +14,14 @@ every test passes. Run it with:
 messages, attachments, or the access log; tests grep the source for
 forbidden statements as well as exercising behaviour. Supersession,
 quarantine, and dismissal round-trip reversibly. Summary regenerations
-append to a restorable history.
+append to a restorable history. The only deletes anywhere are the three
+human erasers on the admin surface (fact, file, message - the message
+one is #45, closing crossband#106's loop): `test_message_erase.py`
+proves the erase is owner-gated and single-row, search and health stay
+honest afterwards, live facts mined from an erased message resurface
+for review instead of vanishing, attachments are counted not cascaded,
+and every eraser journals a content-free `erasures` row - what was
+erased is gone, that it was erased is not.
 
 **Extraction walls.** Ungrounded names quarantine. Ungrounded or
 relative dates never mint an event date; a missing year comes from the

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -1,8 +1,9 @@
 """HTTP API — the full surface, per docs/API.md (contract v1).
 
 Local-only by default: serving on a non-loopback host without an auth token is
-refused at startup. DELETE /facts/{id} is the single hard-delete path in the
-entire service, and it only exists here — human-initiated by definition.
+refused at startup. Hard deletes exist ONLY here and ONLY as the three human
+erasers — DELETE /facts/{id}, /attachments/{id}, /messages/{id} — each of
+which journals a content-free tombstone in `erasures` (#45).
 
 Exact-row endpoints (GET /facts, GET /review, and every verb that reads or
 writes ONE existing fact by id — PATCH, supersede, approve, dismiss, DELETE)
@@ -50,6 +51,7 @@ import os
 import re
 import secrets
 import stat
+import time
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -1218,13 +1220,15 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
 
     @app.delete("/v1/facts/{fact_id}", dependencies=[Depends(_admin_auth)])
     def hard_delete(fact_id: int):
-        # THE only hard delete in the service — human-initiated via API/UI.
+        # One of the three human erasers (facts / attachments / messages);
+        # each journals a content-free tombstone in `erasures` (#45).
         c = con()
         try:
             cur = c.execute("DELETE FROM facts WHERE id=?", (fact_id,))
-            c.commit()
             if not cur.rowcount:
                 raise HTTPException(404, "no such fact")
+            db.journal_erasure(c, "fact", f"fact:{fact_id}")
+            c.commit()
             return {"deleted": fact_id}
         finally:
             c.close()
@@ -1315,6 +1319,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
             c.execute("DELETE FROM attachments WHERE id=?", (att_id,))
             shared = c.execute("SELECT 1 FROM attachments WHERE stored_name=? LIMIT 1",
                                (row["stored_name"],)).fetchone()
+            db.journal_erasure(c, "attachment", f"attachment:{att_id}")
             c.commit()
         finally:
             c.close()
@@ -1323,6 +1328,95 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
             (settings.data_dir / "attachments" / row["stored_name"]).unlink(missing_ok=True)
             removed = True
         return {"deleted": att_id, "file_removed": removed}
+
+    # ---- messages (admin surface): resolve a producer's ref, and the one
+    # message eraser (#45 - the human hand behind crossband#106's honesty) ----
+
+    @app.get("/v1/messages/resolve", dependencies=[Depends(_admin_auth)])
+    def resolve_message(source_app: str, conversation: str, message: str):
+        # A producer names a message as (source_app, conversation external
+        # id, message external id) - it never sees our row ids. This bridge
+        # exists so an erase link can land on the admin page prefilled, with
+        # a preview the owner confirms BEFORE typing DELETE. Owner-gated:
+        # the preview is verbatim content, same posture as /v1/search.
+        c = con()
+        try:
+            conv = c.execute(
+                "SELECT id, title FROM conversations "
+                "WHERE source_app=? AND external_id=?",
+                (source_app, conversation)).fetchone()
+            row = conv and c.execute(
+                "SELECT id, speaker, content, created_at FROM messages "
+                "WHERE conversation_id=? AND external_id=?",
+                (conv["id"], message)).fetchone()
+            if not row:
+                raise HTTPException(404, "no such message")
+            live = c.execute(
+                "SELECT COUNT(*) AS n FROM facts WHERE source_message_id=? "
+                "AND invalidated_at IS NULL AND quarantined_at IS NULL",
+                (row["id"],)).fetchone()["n"]
+            atts = c.execute(
+                "SELECT COUNT(*) AS n FROM attachments "
+                "WHERE conversation_id=? AND message_external_id=?",
+                (conv["id"], message)).fetchone()["n"]
+        finally:
+            c.close()
+        text = row["content"] or ""
+        return {"id": row["id"], "speaker": row["speaker"],
+                "created_at": row["created_at"],
+                "conversation_title": conv["title"],
+                "excerpt": text[:REVIEW_EXCERPT_CHARS],
+                "truncated": len(text) > REVIEW_EXCERPT_CHARS,
+                "live_facts": live, "attachments": atts}
+
+    @app.delete("/v1/messages/{message_id}", dependencies=[Depends(_admin_auth)])
+    def hard_delete_message(message_id: int):
+        # The messages twin of the facts eraser. A voice turn discarded at
+        # the source (crossband#106) may already be ingested here, and the
+        # append-only invariant rightly stops every AUTOMATED path from
+        # touching the copy; this is the human hand. One row, owner auth,
+        # no bulk form - and no producer's code ever calls it.
+        #
+        # Facts mined from the row are NOT deleted: live ones quarantine
+        # with a `source-deleted:` reason and surface in review, because
+        # silently vanishing derived knowledge would make the erasure
+        # dishonest in the other direction. Attachments that rode the
+        # message keep their own eraser; the response counts what stays.
+        c = con()
+        try:
+            row = c.execute(
+                "SELECT m.id, m.external_id, m.content, m.conversation_id, "
+                "cv.source_app, cv.external_id AS conv_ref "
+                "FROM messages m JOIN conversations cv "
+                "ON cv.id=m.conversation_id WHERE m.id=?",
+                (message_id,)).fetchone()
+            if not row:
+                raise HTTPException(404, "no such message")
+            # external-content FTS needs an explicit tombstone before the row goes
+            c.execute("INSERT INTO messages_fts(messages_fts, rowid, content) "
+                      "VALUES('delete', ?, ?)", (message_id, row["content"]))
+            c.execute("DELETE FROM messages WHERE id=?", (message_id,))
+            held = c.execute(
+                "UPDATE facts SET quarantined_at=?, quarantine_reason=? "
+                "WHERE source_message_id=? "
+                "AND invalidated_at IS NULL AND quarantined_at IS NULL",
+                (time.time(),
+                 "source-deleted: origin message erased by owner",
+                 message_id)).rowcount
+            kept = c.execute(
+                "SELECT COUNT(*) AS n FROM attachments "
+                "WHERE conversation_id=? AND message_external_id=?",
+                (row["conversation_id"], row["external_id"])).fetchone()["n"]
+            db.journal_erasure(
+                c, "message",
+                f"message:{message_id} "
+                f"conv:{row['source_app']}/{row['conv_ref']} "
+                f"ref:{row['external_id']}")
+            c.commit()
+        finally:
+            c.close()
+        return {"deleted": message_id, "facts_held": held,
+                "attachments_kept": kept}
 
     @app.get("/v1/review", dependencies=[Depends(_admin_auth)])
     def review():

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -144,6 +144,17 @@ CREATE TRIGGER IF NOT EXISTS attachment_captions_ai AFTER INSERT ON attachment_c
            (SELECT extracted_text FROM attachments WHERE id = new.attachment_id));
   INSERT INTO attachments_fts(rowid, extracted_text) VALUES (new.attachment_id, new.caption);
 END;
+
+-- The erasure journal (#45): each use of the three human erasers (fact /
+-- attachment / message) appends one CONTENT-FREE row - kind, refs/ids, when.
+-- What was erased is gone; THAT it was erased is not. Additive to schema v1,
+-- created on init like access_log.
+CREATE TABLE IF NOT EXISTS erasures(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts REAL NOT NULL,
+  kind TEXT NOT NULL,                     -- fact | attachment | message
+  ref TEXT NOT NULL                       -- ids only, never content
+);
 """
 
 
@@ -153,6 +164,14 @@ def connect(db_path: Path) -> sqlite3.Connection:
     con.execute("PRAGMA busy_timeout = 30000")
     con.execute("PRAGMA foreign_keys = ON")
     return con
+
+
+def journal_erasure(con, kind: str, ref: str) -> None:
+    """One content-free row per human erasure - ids in `ref`, never content.
+    Caller commits: the journal row must land in the SAME transaction as the
+    delete it records."""
+    con.execute("INSERT INTO erasures(ts, kind, ref) VALUES (?,?,?)",
+                (time.time(), kind, ref))
 
 
 def init(settings) -> None:

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -635,10 +635,12 @@
       <summary>Danger zone</summary>
       <div class="body">
         <p><b>The only real erasers in the app — and only you can press them.</b> Everything else
-           hides or retires things reversibly; these permanently destroy one fact or one stored
-           file, with no undo and no history kept. Prefer Supersede (in the ledger) or Dismiss
-           (in review) unless it should never have existed. Type the id and the word DELETE to
-           enable each button. File ids are in the Files section above.</p>
+           hides or retires things reversibly; these permanently destroy one fact, one stored
+           file, or one archived message. No undo; the only trace kept is a content-free note
+           that an erasure happened. Prefer Supersede (in the ledger) or Dismiss (in review)
+           unless it should never have existed. Type the id and the word DELETE to enable each
+           button. File ids are in the Files section above; message erases usually arrive
+           prefilled via the erase link in the app that captured the message.</p>
         <div class="fields">
           <input type="number" id="del-id" min="1" placeholder="fact id"
                  oninput="checkDelete()" aria-label="Fact id to delete">
@@ -653,6 +655,15 @@
                  oninput="checkDeleteAtt()" autocomplete="off" aria-label="Type DELETE to confirm file deletion">
           <button class="danger" id="del-att-btn" disabled onclick="hardDeleteAttachment()">Delete file permanently</button>
         </div>
+        <div class="fields" style="margin-top: var(--space-3)">
+          <input type="number" id="del-msg-id" min="1" placeholder="message id"
+                 oninput="checkDeleteMsg()" aria-label="Message id to delete">
+          <input type="text" id="del-msg-confirm" placeholder="type DELETE to confirm"
+                 oninput="checkDeleteMsg()" autocomplete="off" aria-label="Type DELETE to confirm message deletion">
+          <button class="danger" id="del-msg-btn" disabled onclick="hardDeleteMessage()">Delete message permanently</button>
+        </div>
+        <div id="del-msg-preview" hidden
+             style="margin-top: var(--space-2); font-size: 12px; line-height: 16px; color: var(--dim)"></div>
       </div>
     </details>
   </div>
@@ -1249,6 +1260,58 @@ async function hardDeleteAttachment() {
   loadFiles(); loadHealth();
 }
 
+function checkDeleteMsg() {
+  const id = parseInt($("del-msg-id").value, 10);
+  $("del-msg-btn").disabled = !(Number.isInteger(id) && id > 0 &&
+                                $("del-msg-confirm").value === "DELETE");
+}
+
+async function hardDeleteMessage() {
+  const id = parseInt($("del-msg-id").value, 10);
+  if (!Number.isInteger(id) || id <= 0) return;
+  const res = await api(`/messages/${id}`, { method: "DELETE" });
+  const bits = [`Message #${id} permanently deleted.`];
+  if (res.facts_held) bits.push(`${res.facts_held} fact${res.facts_held === 1 ? "" : "s"} mined from it moved to review.`);
+  if (res.attachments_kept) bits.push(`${res.attachments_kept} attached file${res.attachments_kept === 1 ? "" : "s"} kept (erase separately if needed).`);
+  toast(bits.join(" "), true);
+  $("del-msg-id").value = ""; $("del-msg-confirm").value = "";
+  $("del-msg-preview").hidden = true;
+  checkDeleteMsg();
+  loadLedger(); loadReview(); loadHealth();
+}
+
+// A producing app can link straight to an erase:
+//   #erase=<source app>/<conversation ref>/<message ref>
+// (crossband's discard banner does, #45). Resolve the ref to OUR row id,
+// prefill the danger zone and show what would be erased with its blast
+// radius - the human still types DELETE and presses the button.
+async function prefillEraseFromHash() {
+  const m = location.hash.match(/^#erase=([^/]+)\/([^/]+)\/(.+)$/);
+  if (!m) return;
+  const [app_, conv, ref] = m.slice(1).map(decodeURIComponent);
+  let d;
+  try {
+    d = await api(`/messages/resolve?source_app=${encodeURIComponent(app_)}` +
+                  `&conversation=${encodeURIComponent(conv)}&message=${encodeURIComponent(ref)}`);
+  } catch (e) {
+    toast("Couldn't find that message in the archive: " + e.message, false);
+    return;
+  }
+  const zone = document.querySelector("details.danger-zone");
+  for (let el = zone; el; el = el.parentElement && el.parentElement.closest("details")) el.open = true;
+  $("del-msg-id").value = String(d.id);
+  const extra = [];
+  if (d.live_facts) extra.push(`${d.live_facts} live fact${d.live_facts === 1 ? "" : "s"} mined from it will move to review`);
+  if (d.attachments) extra.push(`${d.attachments} attached file${d.attachments === 1 ? "" : "s"} will stay`);
+  $("del-msg-preview").innerHTML =
+    `Message #${d.id} · ${esc(d.speaker)} · “${esc(d.excerpt)}${d.truncated ? "…" : ""}”` +
+    (extra.length ? ` · ${esc(extra.join(" · "))}` : "");
+  $("del-msg-preview").hidden = false;
+  checkDeleteMsg();
+  zone.scrollIntoView({ block: "center" });
+  $("del-msg-confirm").focus();
+}
+
 // ---- files: every attachment the memory holds ----
 
 async function loadFiles() {
@@ -1573,6 +1636,7 @@ async function removePasskey(id) {
 // ---- boot ----
 
 loadReview(); loadSummary(); loadLedger(); loadFiles(); loadHealth(); loadPasskeys();
+prefillEraseFromHash();
 setInterval(() => { if (document.visibilityState === "visible") loadHealth(); }, 15000);
 </script>
 </body>

--- a/tests/test_message_erase.py
+++ b/tests/test_message_erase.py
@@ -1,0 +1,193 @@
+"""The message eraser - the human hand behind crossband#106's honesty (#45).
+
+A voice turn discarded at its source may already be ingested here, and the
+append-only invariant rightly stops every automated path from touching the
+copy. The contract under test:
+
+- resolve: a producer's ref (source_app, conversation, message) maps to our
+  row id with an owner-gated preview; unknown refs 404;
+- erase: one row by id, owner-gated; the row leaves the archive AND the
+  search index (fts stays in sync, health stays ok); live facts mined from
+  it quarantine with a source-deleted reason and surface in review; facts
+  already held keep their own reason; attachments are counted, never
+  cascaded;
+- every human eraser (fact / attachment / message) journals a content-free
+  row in `erasures`: what was erased is gone, that it was erased is not.
+"""
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import db as mdb
+from memory_service import ledger
+from memory_service.api import create_app
+
+
+@pytest.fixture
+def client(settings, fake_llm):
+    app = create_app(settings)
+    c = TestClient(app, base_url="http://127.0.0.1",
+                   headers={"Authorization": f"Bearer {app.state.admin_token}"})
+    c.app = app
+    return c
+
+
+def _ingest(client, ref="m1", content="the kakapo is a flightless parrot"):
+    r = client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "c1",
+        "title": "birds",
+        "messages": [{"external_id": ref, "speaker": "user",
+                       "content": content,
+                       "created_at": "2026-08-13T10:00:00+10:00"}]})
+    assert r.json()["ingested"] == 1
+
+
+def _row(settings, sql, *args):
+    con = mdb.connect(settings.db_path)
+    try:
+        return con.execute(sql, args).fetchone()
+    finally:
+        con.close()
+
+
+def _msg_id(settings, ref):
+    return _row(settings, "SELECT id FROM messages WHERE external_id=?",
+                ref)["id"]
+
+
+def test_resolve_maps_a_producer_ref_to_our_row(client, settings):
+    _ingest(client)
+    mid = _msg_id(settings, "m1")
+    d = client.get("/v1/messages/resolve", params={
+        "source_app": "multi-model-chat", "conversation": "c1",
+        "message": "m1"}).json()
+    assert d["id"] == mid and d["speaker"] == "user"
+    assert "kakapo" in d["excerpt"]
+    assert d["live_facts"] == 0 and d["attachments"] == 0
+    assert client.get("/v1/messages/resolve", params={
+        "source_app": "multi-model-chat", "conversation": "c1",
+        "message": "nope"}).status_code == 404
+
+
+def test_erase_removes_the_row_and_search_stays_honest(client, settings):
+    _ingest(client, ref="m1", content="the kakapo is a flightless parrot")
+    _ingest(client, ref="m2", content="the kea is an alpine parrot")
+    mid = _msg_id(settings, "m1")
+    r = client.delete(f"/v1/messages/{mid}")
+    assert r.json() == {"deleted": mid, "facts_held": 0,
+                        "attachments_kept": 0}
+    # gone from the archive and from search; the neighbour is untouched
+    assert client.post("/v1/search",
+                       json={"query": "kakapo"}).json()["hits"] == []
+    assert len(client.post("/v1/search",
+                           json={"query": "kea"}).json()["hits"]) == 1
+    h = client.get("/v1/health").json()
+    assert h["status"] == "ok" and h["db"]["fts_in_sync"] is True
+    assert client.delete(f"/v1/messages/{mid}").status_code == 404
+
+
+def test_live_facts_resurface_and_held_ones_keep_their_reason(client,
+                                                              settings):
+    _ingest(client)
+    mid = _msg_id(settings, "m1")
+    con = mdb.connect(settings.db_path)
+    try:
+        conv = con.execute("SELECT conversation_id FROM messages WHERE id=?",
+                           (mid,)).fetchone()["conversation_id"]
+        live = ledger.add_fact(con, "Alex keeps a kakapo as company.",
+                               settings, origin_agent="user",
+                               conversation_id=conv,
+                               source_message_id=mid)["id"]
+        held = ledger.add_fact(con, "A guest said something held here.",
+                               settings, origin_agent="miner",
+                               conversation_id=conv, source_message_id=mid,
+                               quarantine_reason="guest-attribution: stated by guest")["id"]
+    finally:
+        con.close()
+
+    r = client.delete(f"/v1/messages/{mid}").json()
+    assert r["facts_held"] == 1
+
+    rows = client.get("/v1/review").json()["facts"]
+    mine = [f for f in rows if f["id"] == live]
+    assert mine and mine[0]["reason_class"] == "source-deleted"
+    assert mine[0]["source"] is None       # the origin is honestly gone
+    kept = _row(settings, "SELECT quarantine_reason FROM facts WHERE id=?",
+                held)
+    assert kept["quarantine_reason"].startswith("guest-attribution")
+
+
+def test_attachments_are_counted_never_cascaded(client, settings):
+    _ingest(client)
+    mid = _msg_id(settings, "m1")
+    con = mdb.connect(settings.db_path)
+    try:
+        conv = con.execute("SELECT conversation_id FROM messages WHERE id=?",
+                           (mid,)).fetchone()["conversation_id"]
+        con.execute(
+            "INSERT INTO attachments(conversation_id, message_external_id, "
+            "filename, mime, size, sha256, stored_name, extracted_text, "
+            "created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            (conv, "m1", "notes.txt", "text/plain", 5, "ab" * 32, "ab" * 32,
+             "some extracted words", time.time()))
+        con.commit()
+    finally:
+        con.close()
+    r = client.delete(f"/v1/messages/{mid}").json()
+    assert r["attachments_kept"] == 1
+    assert _row(settings,
+                "SELECT id FROM attachments WHERE message_external_id=?",
+                "m1") is not None
+
+
+def test_every_eraser_journals_content_free(client, settings):
+    _ingest(client, content="the secret kakapo whisper phrase")
+    mid = _msg_id(settings, "m1")
+    fid = client.post("/v1/facts", json={
+        "content": "Alex enjoys long walks daily.",
+        "origin_agent": "user"}).json()["id"]
+    con = mdb.connect(settings.db_path)
+    try:
+        conv = con.execute("SELECT id FROM conversations").fetchone()["id"]
+        aid = con.execute(
+            "INSERT INTO attachments(conversation_id, message_external_id, "
+            "filename, mime, size, sha256, stored_name, extracted_text, "
+            "created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            (conv, "m9", "notes.txt", "text/plain", 5, "cd" * 32, "cd" * 32,
+             "attached secret words", time.time())).lastrowid
+        con.commit()
+    finally:
+        con.close()
+
+    assert client.delete(f"/v1/messages/{mid}").status_code == 200
+    assert client.delete(f"/v1/facts/{fid}").status_code == 200
+    assert client.delete(f"/v1/attachments/{aid}").status_code == 200
+
+    con = mdb.connect(settings.db_path)
+    try:
+        rows = con.execute("SELECT ts, kind, ref FROM erasures "
+                           "ORDER BY id").fetchall()
+    finally:
+        con.close()
+    assert [r["kind"] for r in rows] == ["message", "fact", "attachment"]
+    assert all(r["ts"] > 0 for r in rows)
+    joined = " ".join(r["ref"] for r in rows)
+    # refs point, they never quote: no erased content may survive in them
+    for word in ("whisper", "walks", "secret"):
+        assert word not in joined
+    assert f"message:{mid}" in joined
+    assert "conv:multi-model-chat/c1" in joined
+
+
+def test_both_routes_are_owner_gated(client, settings):
+    _ingest(client)
+    mid = _msg_id(settings, "m1")
+    bare = TestClient(client.app, base_url="http://127.0.0.1")
+    assert bare.get("/v1/messages/resolve", params={
+        "source_app": "multi-model-chat", "conversation": "c1",
+        "message": "m1"}).status_code in (401, 403)
+    assert bare.delete(f"/v1/messages/{mid}").status_code in (401, 403)
+    assert _row(settings, "SELECT id FROM messages WHERE id=?",
+                mid) is not None


### PR DESCRIPTION
Fixes #45, closing the crossband#106 loop. Owner-gated single-message hard delete: archive + search index both honest, live mined facts resurface for review (source-deleted reason, grouped by #34's classes), attachments counted never cascaded, and all three human erasers now journal content-free erasures rows. The admin page accepts #erase=<app>/<conversation>/<message> deep links so crossband's discard banner can land here prefilled with a preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)