### PR TITLE
Person records: the fleet's identity home, slice 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- Person records land (#33, first slice): membro is now the fleet's
+  durable home for who-is-who. Capture apps create people and upload
+  their voice clips (content-addressed, owner-only, kept in full);
+  guest facts link to the person on sight of a matching alias; a
+  one-press forget deletes the audio, marks the person forgotten for
+  every syncing app, and moves their approved facts back into review
+  as one group - nothing silently deleted. A model's name can never
+  become a person, enforced server-side too.
+
 - The owner can erase one archived message (#45), finishing what
   crossband's discard starts: a voice turn deleted at the source may
   already have a copy here, and nothing automated may touch it. The

--- a/docs/API.md
+++ b/docs/API.md
@@ -631,6 +631,42 @@ quarantine with a `source-deleted:` reason and surface in review (the owner
 decides each - derived knowledge never silently vanishes); attachments that
 rode the message are counted in the response, never cascaded. Journals to
 `erasures`. **Requires the owner admin token, even on loopback.**
+
+### Person records (#33, the fleet's identity home)
+
+Apps that capture voices create person records here and upload their
+accepted clips, so a learned voice survives a lost client data directory.
+Membro never does voice identification itself; it records what apps
+assert. All five routes **require the owner admin token, even on
+loopback**:
+
+`GET /v1/persons?since=<time>`: person records changed since then,
+forgotten marks included - a syncing app deletes its local copies of
+anyone marked forgotten. Each record carries slug, display name (and
+whether the owner set it - an owner-set name survives client updates),
+relationship, aliases, clip count, and timestamps.
+
+`POST /v1/persons`: create or update by slug. Aliases combine; an alias
+already belonging to a different person is refused (409), never
+reassigned. A name membro has seen as a MODEL speaker label is refused
+outright - the crossband participant boundary (#65), backstopped
+server-side. Existing `guest:<alias>` facts link to the person on upsert
+(the response reports how many).
+
+`POST /v1/persons/{slug}/anchors`: upload one clip (base64). Content-
+addressed - the same bytes for the same person is a no-op. Files live
+under `voice_anchors/`, owner-only modes, every clip kept (owner
+decision: no server-side pruning).
+
+`GET /v1/persons/{slug}/anchors` and `.../{id}/file`: list and download,
+for rebuilding a lost client cache.
+
+`POST /v1/persons/{slug}/forget`: the one-press forget. Deletes the
+audio from disk (one content-free `erasures` row), marks the person
+forgotten, and moves their approved facts back into review as one
+person-forgotten group (owner decision: nothing silently deleted).
+Anchor routes answer `410 gone` afterwards; the record itself stays
+listed so syncing apps learn to delete their copies.
 The three summary-version routes below, unlike the attachment routes above,
 are **NOT** gated: they answer an unauthenticated loopback caller.
 `GET /v1/summary/versions`: every generated profile, newest first (metadata

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -23,6 +23,14 @@ for review instead of vanishing, attachments are counted not cascaded,
 and every eraser journals a content-free `erasures` row - what was
 erased is gone, that it was erased is not.
 
+**Person records (#33).** Owner-set names survive client updates; an
+alias can never be reassigned to a different person; a model speaker
+label can never become a person; clips are content-addressed and
+owner-only on disk; sync includes forgotten marks; forget deletes the
+audio (journalled content-free), moves the person's approved facts back
+into review as one group and leaves held facts alone; every route
+refuses callers without the owner token (`test_person_records.py`).
+
 **Extraction walls.** Ungrounded names quarantine. Ungrounded or
 relative dates never mint an event date; a missing year comes from the
 conversation. Untrusted sources quarantine. System-meta and

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -44,6 +44,7 @@ secret. Sessions remain opaque, HttpOnly, SameSite=Strict, in-memory (cleared
 on restart), expiring, and revocable, exactly as v4 left them.
 """
 
+import base64
 import datetime
 import hmac
 import json
@@ -68,7 +69,7 @@ from webauthn.helpers.structs import (AuthenticatorAttachment,
                                       ResidentKeyRequirement,
                                       UserVerificationRequirement)
 
-from . import access, auth, db, embeddings, episodic, jobs, ledger, mining, passkeys, recall, summary, viz, walls
+from . import access, auth, db, embeddings, episodic, jobs, ledger, mining, passkeys, persons, recall, summary, viz, walls
 from .config import Settings, load_settings
 
 
@@ -1417,6 +1418,122 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
             c.close()
         return {"deleted": message_id, "facts_held": held,
                 "attachments_kept": kept}
+
+    # ---- persons (#33): the fleet's identity home. Capture apps create
+    # and upload; the admin surface renames/merges/forgets; forget is the
+    # one-press flow whose numbered steps live on the issue. ----
+
+    class PersonBody(BaseModel):
+        slug: str = Field(min_length=1, max_length=80)
+        display_name: str = Field(min_length=1, max_length=80)
+        aliases: list[str] = []
+        relationship: str | None = None
+        origin_client: str = ""
+
+    class AnchorBody(BaseModel):
+        data_b64: str
+        seconds: float = 0
+        score: float = 0
+        source: str = ""
+        captured_at: float = 0
+        client: str = ""
+
+    def _person_or_404(c, slug, allow_forgotten=False):
+        row = c.execute("SELECT * FROM persons WHERE slug=?",
+                        (slug,)).fetchone()
+        if not row:
+            raise HTTPException(404, "no such person")
+        if row["forgotten_at"] and not allow_forgotten:
+            raise HTTPException(410, "this person was forgotten")
+        return row
+
+    @app.get("/v1/persons", dependencies=[Depends(_admin_auth)])
+    def list_persons(since: float = 0):
+        # Forgotten people are INCLUDED - the mark is how a syncing app
+        # learns to delete its local copies (forgetting step 3).
+        c = con()
+        try:
+            rows = c.execute(
+                "SELECT * FROM persons WHERE updated_at > ? "
+                "ORDER BY id", (since,)).fetchall()
+            return {"persons": [persons.out(c, r) for r in rows]}
+        finally:
+            c.close()
+
+    @app.post("/v1/persons", dependencies=[Depends(_admin_auth)])
+    def upsert_person(body: PersonBody):
+        c = con()
+        try:
+            return persons.upsert(
+                c, settings, slug=body.slug.strip(),
+                display_name=body.display_name,
+                aliases=body.aliases, relationship=body.relationship,
+                origin_client=body.origin_client)
+        except ValueError as e:
+            raise HTTPException(409, str(e))
+        finally:
+            c.close()
+
+    @app.post("/v1/persons/{slug}/anchors",
+              dependencies=[Depends(_admin_auth)])
+    def upload_anchor(slug: str, body: AnchorBody):
+        try:
+            data = base64.b64decode(body.data_b64, validate=True)
+        except Exception:
+            raise HTTPException(400, "data_b64 is not valid base64")
+        if not data:
+            raise HTTPException(400, "empty clip")
+        c = con()
+        try:
+            person = _person_or_404(c, slug)
+            return persons.add_clip(
+                c, settings, person, data=data, seconds=body.seconds,
+                score=body.score, source=body.source,
+                captured_at=body.captured_at, client=body.client)
+        finally:
+            c.close()
+
+    @app.get("/v1/persons/{slug}/anchors",
+             dependencies=[Depends(_admin_auth)])
+    def list_anchors(slug: str):
+        c = con()
+        try:
+            person = _person_or_404(c, slug)
+            rows = [dict(r) for r in c.execute(
+                "SELECT id, sha256, seconds, score, source, captured_at, "
+                "client FROM voice_anchors WHERE person_id=? ORDER BY id",
+                (person["id"],))]
+            return {"anchors": rows}
+        finally:
+            c.close()
+
+    @app.get("/v1/persons/{slug}/anchors/{anchor_id}/file",
+             dependencies=[Depends(_admin_auth)])
+    def anchor_file(slug: str, anchor_id: int):
+        c = con()
+        try:
+            person = _person_or_404(c, slug)
+            row = c.execute(
+                "SELECT stored_name FROM voice_anchors WHERE id=? AND "
+                "person_id=?", (anchor_id, person["id"])).fetchone()
+        finally:
+            c.close()
+        if not row:
+            raise HTTPException(404, "no such clip")
+        path = persons.clips_dir(settings) / row["stored_name"]
+        if not path.exists():
+            raise HTTPException(410, "clip bytes missing on disk")
+        return FileResponse(path, media_type="audio/wav")
+
+    @app.post("/v1/persons/{slug}/forget",
+              dependencies=[Depends(_admin_auth)])
+    def forget_person(slug: str):
+        c = con()
+        try:
+            person = _person_or_404(c, slug)
+            return persons.forget(c, settings, person)
+        finally:
+            c.close()
 
     @app.get("/v1/review", dependencies=[Depends(_admin_auth)])
     def review():

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS facts(
   superseded_by INTEGER,
   quarantined_at REAL,                         -- held out of recall+summary pending review
   quarantine_reason TEXT,
-  review_dismissed_at REAL                     -- reviewed-and-kept-out (stays quarantined)
+  review_dismissed_at REAL,                    -- reviewed-and-kept-out (stays quarantined)
+  person_id INTEGER                            -- #33: the person record this fact links to
 );
 
 CREATE TABLE IF NOT EXISTS conversations(
@@ -145,6 +146,41 @@ CREATE TRIGGER IF NOT EXISTS attachment_captions_ai AFTER INSERT ON attachment_c
   INSERT INTO attachments_fts(rowid, extracted_text) VALUES (new.attachment_id, new.caption);
 END;
 
+-- Person records (#33): the fleet's identity home. Apps capture voices
+-- and assert identity; membro records it durably. A person row is never
+-- deleted - forgetting marks it (forgotten_at) and deletes only the audio.
+CREATE TABLE IF NOT EXISTS persons(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,          -- stable id other apps use, e.g. 'p-9f3a2c'
+  display_name TEXT NOT NULL,
+  name_owner_set INTEGER NOT NULL DEFAULT 0,  -- owner renamed it: client upserts can't change it
+  relationship TEXT NOT NULL DEFAULT '',      -- owner-set free text ('partner', 'colleague')
+  created_at REAL NOT NULL,
+  origin_client TEXT NOT NULL DEFAULT '',     -- which app first created it
+  updated_at REAL NOT NULL DEFAULT 0, -- stamped on every change; what ?since= filters on
+  merged_into INTEGER,                -- set when merged into another person; row kept
+  forgotten_at REAL                   -- set when forgotten; how other apps find out
+);
+
+CREATE TABLE IF NOT EXISTS person_aliases(
+  person_id INTEGER NOT NULL REFERENCES persons(id),
+  alias TEXT NOT NULL UNIQUE COLLATE NOCASE,  -- an alias points at exactly one person
+  kind TEXT NOT NULL DEFAULT 'spelling'       -- spelling | pronunciation
+);
+
+CREATE TABLE IF NOT EXISTS voice_anchors(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  person_id INTEGER NOT NULL REFERENCES persons(id),
+  sha256 TEXT NOT NULL,               -- file fingerprint; the same clip is never stored twice
+  stored_name TEXT NOT NULL,          -- file on disk under voice_anchors/, owner-only
+  seconds REAL NOT NULL DEFAULT 0,
+  score REAL NOT NULL DEFAULT 0,      -- the uploading app's quality score, kept for reference
+  source TEXT NOT NULL DEFAULT '',    -- accumulated | introduction | correction
+  captured_at REAL NOT NULL DEFAULT 0,
+  client TEXT NOT NULL DEFAULT '',
+  UNIQUE(person_id, sha256)
+);
+
 -- The erasure journal (#45): each use of the three human erasers (fact /
 -- attachment / message) appends one CONTENT-FREE row - kind, refs/ids, when.
 -- What was erased is gone; THAT it was erased is not. Additive to schema v1,
@@ -187,6 +223,11 @@ def init(settings) -> None:
             raise RuntimeError(
                 f"database schema v{ver} is newer than this code (v{SCHEMA_VERSION}) — refusing to open")
         con.executescript(SCHEMA)
+        # #33 additive column on an existing DB: IF NOT EXISTS cannot add
+        # columns, so guard an ALTER by inspecting the live table.
+        cols = {r[1] for r in con.execute("PRAGMA table_info(facts)")}
+        if "person_id" not in cols:
+            con.execute("ALTER TABLE facts ADD COLUMN person_id INTEGER")
         con.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         con.commit()
         # Cheap (row-count comparison) and safe (no-op unless desynced) — see

--- a/memory_service/persons.py
+++ b/memory_service/persons.py
@@ -1,0 +1,223 @@
+"""Person records: the fleet's identity home (#33, design on the issue).
+
+Apps capture voices and assert who spoke; membro records it durably. This
+module holds the logic behind the /v1/persons routes: create-or-update,
+alias rules, clip storage, the guest-fact link, and forget.
+
+The five owner decisions (2026-08-14) this implements:
+- every uploaded clip is kept (no server-side keep-best);
+- persons are created only by capture apps (the admin surface renames,
+  merges and forgets - it does not create);
+- a guest fact links to a person always on introduced/owner-correction,
+  and on voice-match only at confidence 0.8+ (the link itself arrives
+  with the wire identity field; the alias-based backfill below covers
+  existing facts);
+- forget also moves that person's approved facts back into review as one
+  person-forgotten group - nothing is silently deleted;
+- relationship is owner-set free text.
+
+Rules enforced here, not left to callers:
+- an alias points at exactly one person; a collision is refused, never
+  guessed;
+- an owner-set display name survives client upserts;
+- a name or alias membro has already seen as a MODEL speaker label in
+  that app is refused outright - the crossband participant boundary
+  (#65/#77), backstopped server-side;
+- clip bytes live under data_dir/voice_anchors/, dir 0700, files 0600,
+  content-addressed by sha256 so the same clip is never stored twice.
+"""
+
+import hashlib
+import os
+import time
+
+from . import db, walls
+
+DIR_NAME = "voice_anchors"
+
+# Sources a human stood behind - mirrors crossband's vouch sources (#83).
+HUMAN_METHODS = ("introduction", "owner-correction")
+
+
+def clips_dir(settings):
+    d = settings.data_dir / DIR_NAME
+    d.mkdir(parents=True, exist_ok=True)
+    os.chmod(d, 0o700)
+    return d
+
+
+def _row(con, slug):
+    return con.execute("SELECT * FROM persons WHERE slug=?",
+                       (slug,)).fetchone()
+
+
+def out(con, person) -> dict:
+    """One person as the API returns it: the row plus aliases and a clip
+    count. No audio and no fact content."""
+    aliases = [dict(r) for r in con.execute(
+        "SELECT alias, kind FROM person_aliases WHERE person_id=? "
+        "ORDER BY alias", (person["id"],))]
+    clips = con.execute("SELECT COUNT(*) AS n FROM voice_anchors "
+                        "WHERE person_id=?", (person["id"],)).fetchone()["n"]
+    return {"slug": person["slug"], "display_name": person["display_name"],
+            "name_owner_set": bool(person["name_owner_set"]),
+            "relationship": person["relationship"],
+            "created_at": person["created_at"],
+            "origin_client": person["origin_client"],
+            "merged_into": person["merged_into"],
+            "forgotten_at": person["forgotten_at"],
+            "aliases": aliases, "clip_count": clips}
+
+
+def model_label_collision(con, name: str, source_app: str = "") -> bool:
+    """The participant boundary's server-side backstop (#65/#77): has this
+    name ever been seen as a MODEL speaker label? A person may never be
+    created under a name the fleet uses for an AI seat."""
+    like = (name or "").strip()
+    if not like:
+        return False
+    rows = con.execute(
+        "SELECT DISTINCT m.speaker FROM messages m "
+        "JOIN conversations c ON c.id = m.conversation_id "
+        "WHERE m.speaker = ? COLLATE NOCASE "
+        + ("AND c.source_app = ?" if source_app else ""),
+        ([like, source_app] if source_app else [like])).fetchall()
+    return any(walls.speaker_class(r["speaker"]) == "model" for r in rows)
+
+
+def upsert(con, settings, *, slug: str, display_name: str,
+           aliases: list | None = None, relationship: str | None = None,
+           origin_client: str = "") -> dict:
+    """Create or update a person by slug (capture apps call this; the
+    admin surface never creates). Owner-set names win: a client upsert
+    updates the display name only while the owner has not renamed.
+    Aliases are combined; one that already belongs to a DIFFERENT person
+    raises ValueError rather than being reassigned."""
+    display_name = " ".join((display_name or "").split())
+    if not slug or not display_name:
+        raise ValueError("slug and display_name are required")
+    person = _row(con, slug)
+    wanted = {display_name} | {a for a in (aliases or []) if a}
+    for name in wanted:
+        if model_label_collision(con, name, origin_client):
+            raise ValueError(
+                f"{name!r} is a model speaker label in this app - an AI "
+                "participant can never become a person (#65)")
+    if person is None:
+        now = time.time()
+        con.execute(
+            "INSERT INTO persons(slug, display_name, relationship, "
+            "created_at, updated_at, origin_client) VALUES(?,?,?,?,?,?)",
+            (slug, display_name, relationship or "", now, now,
+             origin_client))
+        person = _row(con, slug)
+    else:
+        if not person["name_owner_set"]:
+            con.execute("UPDATE persons SET display_name=? WHERE id=?",
+                        (display_name, person["id"]))
+        if relationship is not None and not person["relationship"]:
+            con.execute("UPDATE persons SET relationship=? WHERE id=?",
+                        (relationship, person["id"]))
+    for alias in wanted:
+        owner = con.execute(
+            "SELECT person_id FROM person_aliases WHERE alias=? COLLATE NOCASE",
+            (alias,)).fetchone()
+        if owner and owner["person_id"] != person["id"]:
+            other = con.execute("SELECT slug FROM persons WHERE id=?",
+                                (owner["person_id"],)).fetchone()
+            raise ValueError(
+                f"alias {alias!r} already belongs to "
+                f"{other['slug'] if other else 'another person'} - refusing "
+                "to reassign a name")
+        if not owner:
+            con.execute(
+                "INSERT INTO person_aliases(person_id, alias) VALUES(?,?)",
+                (person["id"], alias))
+    linked = link_guest_facts(con, _row(con, slug))
+    con.execute("UPDATE persons SET updated_at=? WHERE id=?",
+                (time.time(), person["id"]))
+    con.commit()
+    result = out(con, _row(con, slug))
+    result["facts_linked"] = linked
+    return result
+
+
+def link_guest_facts(con, person) -> int:
+    """The migration-step-3 link, applied whenever a person gains aliases:
+    an existing guest fact whose source message was spoken by
+    guest:<alias> links to this person. Only unlinked facts; a name that
+    is ambiguous across persons cannot happen (aliases are unique)."""
+    aliases = [r["alias"] for r in con.execute(
+        "SELECT alias FROM person_aliases WHERE person_id=?",
+        (person["id"],))]
+    if not aliases:
+        return 0
+    labels = [f"guest:{a}" for a in aliases]
+    q = ",".join("?" for _ in labels)
+    cur = con.execute(
+        f"UPDATE facts SET person_id=? WHERE person_id IS NULL AND "
+        f"source_message_id IN (SELECT id FROM messages WHERE speaker "
+        f"COLLATE NOCASE IN ({q}))", [person["id"]] + labels)
+    return cur.rowcount
+
+
+def add_clip(con, settings, person, *, data: bytes, seconds: float = 0,
+             score: float = 0, source: str = "", captured_at: float = 0,
+             client: str = "") -> dict:
+    """Store one clip, content-addressed. The same bytes for the same
+    person is a no-op ({'deduped': True})."""
+    sha = hashlib.sha256(data).hexdigest()
+    dup = con.execute(
+        "SELECT id FROM voice_anchors WHERE person_id=? AND sha256=?",
+        (person["id"], sha)).fetchone()
+    if dup:
+        return {"deduped": True, "anchor_id": dup["id"]}
+    stored = f"{sha}.wav"
+    path = clips_dir(settings) / stored
+    if not path.exists():
+        path.write_bytes(data)
+        os.chmod(path, 0o600)
+    cur = con.execute(
+        "INSERT INTO voice_anchors(person_id, sha256, stored_name, seconds, "
+        "score, source, captured_at, client) VALUES(?,?,?,?,?,?,?,?)",
+        (person["id"], sha, stored, seconds, score, source,
+         captured_at or time.time(), client))
+    con.commit()
+    return {"deduped": False, "anchor_id": cur.lastrowid}
+
+
+def forget(con, settings, person) -> dict:
+    """The one-press forget, exactly the numbered steps on the issue:
+    delete the audio (journalled, content-free), mark the person
+    forgotten, move their approved facts back into review as one
+    person-forgotten group (owner decision 4 - nothing silently
+    deleted), and report what happened. Clip files are shared only by
+    sha collision within the same store, so each stored file whose last
+    row is gone is unlinked."""
+    rows = con.execute("SELECT id, stored_name FROM voice_anchors "
+                       "WHERE person_id=?", (person["id"],)).fetchall()
+    con.execute("DELETE FROM voice_anchors WHERE person_id=?",
+                (person["id"],))
+    removed = 0
+    for r in rows:
+        shared = con.execute(
+            "SELECT 1 FROM voice_anchors WHERE stored_name=? LIMIT 1",
+            (r["stored_name"],)).fetchone()
+        if not shared:
+            (clips_dir(settings) / r["stored_name"]).unlink(missing_ok=True)
+            removed += 1
+    now = time.time()
+    con.execute("UPDATE persons SET forgotten_at=?, updated_at=? WHERE id=?",
+                (now, now, person["id"]))
+    held = con.execute(
+        "UPDATE facts SET quarantined_at=?, quarantine_reason=?, "
+        "review_dismissed_at=NULL WHERE person_id=? "
+        "AND invalidated_at IS NULL AND quarantined_at IS NULL",
+        (now, f"person-forgotten: {person['display_name']} was forgotten "
+              "by the owner - re-review each fact", person["id"])).rowcount
+    db.journal_erasure(
+        con, "voice",
+        f"person:{person['slug']} clips:{len(rows)} files_removed:{removed}")
+    con.commit()
+    return {"forgotten": person["slug"], "clips_deleted": len(rows),
+            "files_removed": removed, "facts_held": held}

--- a/tests/test_person_records.py
+++ b/tests/test_person_records.py
@@ -1,0 +1,193 @@
+"""Person records: the fleet's identity home (#33, slice 1).
+
+The five owner decisions (2026-08-14) under test, plus the rules the
+design states:
+
+- upsert by slug: owner-set names survive client updates, aliases combine,
+  an alias belonging to a different person is refused, and a name membro
+  has seen as a MODEL speaker label is refused outright (#65 backstop);
+- clips are content-addressed (same bytes = no-op), owner-only on disk,
+  and every clip is kept (decision 1);
+- sync: ?since= returns changed records, forgotten marks included;
+- forget runs the numbered steps: audio deleted (journalled,
+  content-free), person marked, that person's APPROVED facts move back
+  into review as one person-forgotten group (decision 4), held facts
+  stay held, and anchor routes answer 410 afterwards;
+- guest-fact linking: an existing fact whose source message was spoken
+  by guest:<alias> links to the person on upsert;
+- every route refuses callers without the owner token.
+"""
+
+import base64
+import os
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import api as api_mod
+from memory_service import db as mdb
+from memory_service import ledger
+
+WAV = b"RIFF" + os.urandom(600)
+WAV2 = b"RIFF" + os.urandom(600)
+
+
+@pytest.fixture
+def client(settings, fake_llm):
+    app = api_mod.create_app(settings)
+    c = TestClient(app, base_url="http://127.0.0.1",
+                   headers={"Authorization": f"Bearer {app.state.admin_token}"})
+    c.app = app
+    c.settings = settings
+    return c
+
+
+def _b64(b):
+    return base64.b64encode(b).decode()
+
+
+def _mk(client, slug="p-alex1", name="Alex", **kw):
+    body = {"slug": slug, "display_name": name,
+            "origin_client": "multi-model-chat", **kw}
+    r = client.post("/v1/persons", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_upsert_owner_name_wins_and_aliases_combine(client, settings):
+    p = _mk(client, aliases=["Al"])
+    assert p["display_name"] == "Alex" and p["clip_count"] == 0
+    # owner renames (admin-side flag set directly - the rename route is
+    # the admin surface slice; the RULE is what matters here)
+    con = mdb.connect(settings.db_path)
+    con.execute("UPDATE persons SET display_name='Alexandra', "
+                "name_owner_set=1 WHERE slug='p-alex1'")
+    con.commit(); con.close()
+    p = _mk(client, name="Alex", aliases=["Ali"])
+    assert p["display_name"] == "Alexandra"          # owner-set survives
+    assert sorted(a["alias"] for a in p["aliases"]) == ["Al", "Alex", "Ali"]
+
+
+def test_alias_of_another_person_is_refused(client):
+    _mk(client, slug="p-a", name="Sam")
+    r = client.post("/v1/persons", json={
+        "slug": "p-b", "display_name": "Sammy", "aliases": ["Sam"]})
+    assert r.status_code == 409
+    assert "already belongs" in r.json()["error"]["message"]
+
+
+def test_a_model_speaker_label_can_never_become_a_person(client):
+    client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "c1",
+        "title": "t", "messages": [{
+            "external_id": "m1", "speaker": "claude",
+            "content": "a model turn arriving on the wire",
+            "created_at": "2026-08-13T10:00:00+10:00"}]})
+    r = client.post("/v1/persons", json={
+        "slug": "p-x", "display_name": "Claude",
+        "origin_client": "multi-model-chat"})
+    assert r.status_code == 409
+    assert "AI participant" in r.json()["error"]["message"]
+
+
+def test_clips_are_content_addressed_and_owner_only(client, settings):
+    _mk(client)
+    r = client.post("/v1/persons/p-alex1/anchors", json={
+        "data_b64": _b64(WAV), "seconds": 2.0, "score": 0.9,
+        "source": "introduction", "client": "multi-model-chat"})
+    assert r.json()["deduped"] is False
+    assert client.post("/v1/persons/p-alex1/anchors", json={
+        "data_b64": _b64(WAV)}).json()["deduped"] is True
+    rows = client.get("/v1/persons/p-alex1/anchors").json()["anchors"]
+    assert len(rows) == 1 and rows[0]["source"] == "introduction"
+    f = client.get(f"/v1/persons/p-alex1/anchors/{rows[0]['id']}/file")
+    assert f.status_code == 200 and f.content == WAV
+    stored = settings.data_dir / "voice_anchors"
+    files = list(stored.iterdir())
+    assert len(files) == 1
+    assert (files[0].stat().st_mode & 0o777) == 0o600
+    assert (stored.stat().st_mode & 0o777) == 0o700
+
+
+def test_sync_since_returns_changes_with_forgotten_marks(client):
+    _mk(client)
+    t0 = time.time()
+    time.sleep(0.02)
+    assert client.get("/v1/persons",
+                      params={"since": t0}).json()["persons"] == []
+    _mk(client, slug="p-b", name="Robin")
+    got = client.get("/v1/persons", params={"since": t0}).json()["persons"]
+    assert [p["slug"] for p in got] == ["p-b"]
+    client.post("/v1/persons/p-alex1/forget")
+    got = client.get("/v1/persons", params={"since": t0}).json()["persons"]
+    assert {p["slug"]: bool(p["forgotten_at"]) for p in got} == {
+        "p-b": False, "p-alex1": True}
+
+
+def test_forget_runs_the_numbered_steps(client, settings):
+    # a guest message, a fact mined from it, and a person with that alias
+    client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "c1",
+        "title": "t", "messages": [{
+            "external_id": "g1", "speaker": "guest:sam",
+            "content": "sam mentioned they play tennis on tuesdays",
+            "created_at": "2026-08-13T10:00:00+10:00"}]})
+    con = mdb.connect(settings.db_path)
+    mid = con.execute("SELECT id FROM messages WHERE speaker='guest:sam'"
+                      ).fetchone()["id"]
+    approved = ledger.add_fact(con, "Sam plays tennis on Tuesdays.",
+                               client.app.state.settings,
+                               origin_agent="miner",
+                               source_app="multi-model-chat",
+                               conversation_id=1,
+                               source_message_id=mid)["id"]
+    held = ledger.add_fact(con, "Sam said something else held.",
+                           client.app.state.settings,
+                           origin_agent="miner", conversation_id=1,
+                           source_message_id=mid,
+                           quarantine_reason="guest-attribution: stated by a guest")["id"]
+    con.close()
+
+    p = _mk(client, slug="p-sam", name="Sam")
+    assert p["facts_linked"] == 2                    # both rode guest:sam
+    client.post("/v1/persons/p-sam/anchors", json={"data_b64": _b64(WAV)})
+    client.post("/v1/persons/p-sam/anchors", json={"data_b64": _b64(WAV2)})
+
+    r = client.post("/v1/persons/p-sam/forget").json()
+    assert r == {"forgotten": "p-sam", "clips_deleted": 2,
+                 "files_removed": 2, "facts_held": 1}
+    # audio really gone from disk
+    assert list((settings.data_dir / "voice_anchors").iterdir()) == []
+    # the approved fact is back in review as a person-forgotten group
+    rows = client.get("/v1/review").json()["facts"]
+    mine = [f for f in rows if f["id"] == approved]
+    assert mine and mine[0]["reason_class"] == "person-forgotten"
+    # the already-held fact keeps its own reason
+    con = mdb.connect(settings.db_path)
+    kept = con.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                       (held,)).fetchone()["quarantine_reason"]
+    con.close()
+    assert kept.startswith("guest-attribution")
+    # the erasure journal gained one content-free row
+    con = mdb.connect(settings.db_path)
+    rows = con.execute("SELECT kind, ref FROM erasures").fetchall()
+    con.close()
+    assert [r["kind"] for r in rows] == ["voice"]
+    assert "p-sam" in rows[0]["ref"] and "tennis" not in rows[0]["ref"]
+    # anchor routes answer 410 gone from now on
+    assert client.post("/v1/persons/p-sam/anchors", json={
+        "data_b64": _b64(WAV)}).status_code == 410
+    assert client.get("/v1/persons/p-sam/anchors").status_code == 410
+
+
+def test_every_route_is_owner_gated(client):
+    _mk(client)
+    bare = TestClient(client.app, base_url="http://127.0.0.1")
+    assert bare.get("/v1/persons").status_code in (401, 403)
+    assert bare.post("/v1/persons", json={
+        "slug": "p-z", "display_name": "Z Z"}).status_code in (401, 403)
+    assert bare.post("/v1/persons/p-alex1/anchors", json={
+        "data_b64": _b64(WAV)}).status_code in (401, 403)
+    assert bare.get("/v1/persons/p-alex1/anchors").status_code in (401, 403)
+    assert bare.post("/v1/persons/p-alex1/forget").status_code in (401, 403)


### PR DESCRIPTION
First build slice of #33 per the settled design and the five owner decisions recorded on the issue: tables, the five owner-token routes, guest-fact linking, and the one-press forget (audio deleted + journalled, person marked for every syncing app, approved facts back to review as one group). Crossband sync, the admin surface, and the wire identity field follow as their own slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)