### PR TITLE
Documentation pass: rules, enforcement, metaphors, line edits (#48, #49, #50, #51)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ## Checklist
 
 - [ ] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q`
-- [ ] No real personal data anywhere in the diff. Synthetic roster only: Alex, wife Sam, daughter Maya, Fairhaven as the stock place name, stock fictional companies (Initech, Globex); a name outside the roster is a review question by definition
+- [ ] No real personal data anywhere in the diff. Fleet synthetic roster only: people Alex, Sam, Dave, Mateo; place Fairhaven; companies AcmeCo, Initech, Globex. A name outside the roster is a review question by definition
 - [ ] The invariants still hold (append-only; episodic record immutable; quarantine honoured; `tests/test_invariants.py`)
 - [ ] CHANGELOG.md entry under Unreleased in this same PR if this is user-visible; docs updated if they now lie
 - [ ] New UI surfaces have a plain-English "what is this & why it matters" explainer

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ## Checklist
 
 - [ ] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q`
-- [ ] No real personal data anywhere in the diff. Synthetic roster only ; Alex, wife Sam, daughter Maya, Fairhaven as the stock place name, stock fictional companies (Initech, Globex); a name outside the roster is a review question by definition
-- [ ] The invariants still hold (append-only; episodic record immutable; quarantine honored ; `tests/test_invariants.py`)
+- [ ] No real personal data anywhere in the diff. Synthetic roster only: Alex, wife Sam, daughter Maya, Fairhaven as the stock place name, stock fictional companies (Initech, Globex); a name outside the roster is a review question by definition
+- [ ] The invariants still hold (append-only; episodic record immutable; quarantine honoured; `tests/test_invariants.py`)
 - [ ] CHANGELOG.md entry under Unreleased in this same PR if this is user-visible; docs updated if they now lie
 - [ ] New UI surfaces have a plain-English "what is this & why it matters" explainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-House convention: user-visible change, one line each, newest first.
+House convention: one entry per user-visible change, newest first. Keep an
+entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
@@ -48,7 +49,7 @@ House convention: user-visible change, one line each, newest first.
   approve anything.
 
 - Review evidence, and provenance only where it is real: a held fact now
-  shows the turn it came from — who said it and what they said — in the
+  shows the turn it came from (who said it and what they said) in the
   review queue, on the admin page and in `GET /review`. A fact the miner
   could not tie to one turn is stored unbound and says so, instead of
   being pinned to whichever message happened to end the mining window.
@@ -64,9 +65,9 @@ House convention: user-visible change, one line each, newest first.
   generic reason; facts a retry binds to a guest's turn still hold with
   the guest named. Nothing about the walls or what quarantines changed.
 - FTS desync self-repair (#37): a search index that has fallen out of
-  step with the stored messages (dropped/recreated, so every search
-  returned zero rows without erroring) is detected and rebuilt
-  automatically at startup, `/health` reports `fts_in_sync` inside the
+  step with the stored messages (dropped or recreated, so every search
+  returned zero rows without erroring) is now detected and rebuilt
+  automatically at startup. `/health` reports `fts_in_sync` inside the
   contractual `db` block and goes `degraded` while it is false, and
   `scripts/rebuild_fts.py` repairs a live instance without a restart.
   Messages, attachments and the fact ledger are untouched - the repair
@@ -88,7 +89,7 @@ House convention: user-visible change, one line each, newest first.
 - Passkey login (#27): enrol a Touch ID / iCloud Keychain passkey from the
   unlocked admin page (Admin → Passkeys) and the lock screen offers it first,
   password one click behind it. The password and recovery secret are
-  unchanged. Passkeys are per web address — enrol `http://localhost:8901`
+  unchanged. Passkeys are per web address: enrol `http://localhost:8901`
   and each trusted host separately; `127.0.0.1` cannot hold one (a browser
   rule: an IP address is not a valid WebAuthn relying party).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,10 @@ sessions with write access working for the maintainer:
 
 - The suite and every workflow run keyless. Never add a hard dependency
   on an API key.
-- No real personal data in any diff: synthetic roster only (see the PR
-  template).
+- No real personal data in any diff. The fleet synthetic roster: people
+  Alex, Sam, Dave, Mateo; place Fairhaven; companies AcmeCo, Initech,
+  Globex. The eval corpora keep their own role-named cast, where the
+  name states the relationship being tested.
 - `data/` is the user's memory. Never read, copy, or quote its contents
   into code, tests, docs, commits, or chat. Debug with disposable
   stores.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,30 @@ git config core.hooksPath .githooks
 - The scope boundaries in [ARCHITECTURE.md](ARCHITECTURE.md) are
   deliberate.
 
+## Writing documentation
+
+Budgets, not taste. `tests/test_doc_style.py` enforces the hard limits;
+the rest is review. The house reference is a 15.5-word average sentence
+with 4% of sentences over 35 words.
+
+- One claim per sentence. Average under 18 words, and keep sentences over
+  35 words under 10% of a document.
+- No em-dashes. Australian English. Plain English over jargon.
+- Caveats earn their own sentence. Appending a limitation to every claim
+  is how the important ones stop reading as important.
+- Antithesis ("X, not Y", "rather than", "instead of") is a tool, not a
+  cadence. If deleting the "not Y" half loses no information, delete it.
+- Never announce your own honesty. "Stated plainly", "the honest reason":
+  delete the phrase, keep the fact.
+- Issue numbers and bug history go in the CHANGELOG and the issue.
+  Reference prose says what is true now.
+- Do not narrate a document's own structure or edit history. Nobody read
+  the previous version.
+- A table cell holds a value and a sentence, not a section.
+- Headings every 30 to 50 lines, so a section can be navigated.
+- One design metaphor at most, and never in [docs/API.md](docs/API.md):
+  a wire contract must not need the design essay read first.
+
 ## Releasing
 
 Versions are ordinary semantic versions in the 0.x range: no stability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,9 +65,7 @@ Also open on loopback, and worth knowing before you assume otherwise:
   but this one returns your own words.
 
 The gate was drawn around exact ledger rows. These four are not exact
-ledger rows, so the gate does not cover them. Stated plainly here
-because the alternative is a reader inferring a guarantee that is not
-in the code.
+ledger rows, so the gate does not cover them.
 
 ## Known limits
 
@@ -75,21 +73,21 @@ in the code.
 - A loopback process can read fact content through `/v1/recall`'s
   bounded projection. A hostile local process is outside this app's
   threat model.
-- No isolation between OS users beyond file permissions. At startup the
-  service chmods exactly two things: `data/` to 0700 and `data/memory.db`
-  to 0600. Two more happen elsewhere. `data/attachments/` is created and
-  chmodded 0700 the first time this process stores or reads an
-  attachment, not at startup, so on an install that has never taken one
-  the directory does not exist. Each attachment file is chmodded 0600
-  when its bytes are first written; storage is content-addressed, so a
-  file already on disk is left as it is rather than re-chmodded. Nothing
-  else under `data/` is chmodded, so snapshots in `data/backups/` and
-  `service.log` keep whatever mode their creator's umask allowed,
-  typically 0644. The SQLite WAL and SHM files are not in that group:
-  SQLite creates them with the mode of the database file itself, so they
-  follow `memory.db` at 0600, and a umask can only clear further bits,
-  never add them. Either way, the 0700 directory is what keeps other
-  users out.
+- No isolation between OS users beyond file permissions. What the service
+  actually sets:
+
+  | path | mode | when |
+  |---|---|---|
+  | `data/` | 0700 | every startup |
+  | `data/memory.db` | 0600 | every startup |
+  | `data/attachments/` | 0700 | first time an attachment is stored or read, so it does not exist on an install that has never taken one |
+  | each attachment file | 0600 | when its bytes are first written; storage is content-addressed, so a file already on disk is left as it is |
+  | `data/backups/`, `service.log` | whatever the creator's umask allowed, typically 0644 | not chmodded at all |
+
+  The SQLite WAL and SHM files follow `memory.db` at 0600: SQLite creates
+  them with the database file's own mode, and a umask can only clear
+  further bits, never add them. Either way, the 0700 directory is what
+  keeps other users out.
 
 ## Operational notes
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -295,7 +295,7 @@ discovered:
 These are the code's behaviour as it stands, recorded here so the document
 does not promise a gate the service does not implement.
 
-## Episodic record (the tapes)
+## Episodic record
 
 `POST /ingest`: append transcript messages (idempotent on `(source_app, external_id)`).
 ```json
@@ -389,7 +389,7 @@ conversation's title as last ingested (empty string if the client never sent
 one); `content` is an FTS snippet with `>>match<<` markers, not the whole
 message.
 
-## Ledger (the cards)
+## Ledger
 
 `POST /facts`: save one fact.
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,46 +5,18 @@ Versioned; breaking changes bump the major version. Clients check `contract_vers
 at handshake and refuse a major mismatch. The same contract-test suite runs in this
 repo's CI (against the real service) and in each client's CI (against the stub).
 
+## Contract rules
+
 - Base URL: `http://127.0.0.1:8901/v1`
 - Local-only: the server refuses to bind a non-loopback address unless
   `MEMORY_AUTH_TOKEN` is set (then: `Authorization: Bearer <token>`).
-- **1.2 (#33): messages on `/ingest` may carry `speaker_identity`** -
+- **1.2 (#33): messages on `/ingest` may carry `speaker_identity`**:
   which person record the sending app believes spoke (`person` slug,
   `confidence` 0..1, `method`: introduced | voice-match | by-elimination
   | owner-correction). Stored verbatim beside the message. A fact born
   from an identified message links to that person when the identity is
-  strong (introduced/owner-correction always; voice-match at 0.8+; weaker
-  never auto-binds). Absent field = exactly the 1.1 behaviour.
-- **1.1: some endpoints require the owner credential ALWAYS, even on
-  loopback.** This is a *separate, stricter* check from the loopback-vs-token
-  rule above. Sixteen routes carry that always-on check, and these are
-  all of them:
-  - `GET /facts`, `GET /review`, and every verb on one existing fact by id:
-    `PATCH /facts/{id}`, `/facts/{id}/supersede`, `/facts/{id}/approve`,
-    `/facts/{id}/dismiss`, `DELETE /facts/{id}`
-  - the two bulk ledger verbs: `POST /facts/quarantine`,
-    `POST /review/dismiss-all`
-  - `POST /search`, `POST /consolidate`, `GET /jobs/{id}`
-  - all four attachment routes: `GET /attachments`,
-    `GET /attachments/{id}/file`, `GET /attachments/{id}/preview`,
-    `DELETE /attachments/{id}`
-
-  No other `/v1` route carries it. Two things sit outside that count
-  without contradicting it: `GET /` is not on the list yet still varies by
-  credential (an unauthenticated caller gets the locked page rather than
-  the admin UI, and no 401), and the loopback-vs-token rule above is a
-  separate gate that governs the whole surface.
-
-  Every other `/v1` route answers an unauthenticated loopback caller,
-  governed only by the loopback-vs-token rule: `/health`,
-  `/disposable-identity`, `/ingest`, `/distill`, `POST /facts` to create,
-  `/recall`, `GET /summary`, **`POST /summary/regenerate` (which rebuilds
-  the live profile) and all three `/summary/versions*` routes (including
-  the one that returns a stored profile in full and the one that restores
-  it over the live profile)**, `POST /backup`, and every `/viz/*` route.
-  See "Owner admin token" below, and "Open on loopback, and what that
-  means" at the end of it for the four a reader is most likely to expect
-  gated.
+  strong: introduced and owner-correction always, voice-match at 0.8+,
+  weaker never auto-binds. Absent field = exactly the 1.1 behaviour.
 - All bodies JSON. Errors the service raises itself use one envelope:
   `{"error": {"code": "...", "message": "..."}}` with conventional HTTP
   status. Two classes come straight from the web framework and keep its
@@ -57,6 +29,47 @@ repo's CI (against the real service) and in each client's CI (against the stub).
   `error` 422.
 - Async operations return `202 {"job_id": "..."}`; poll `GET /jobs/{id}`
   (which requires the owner credential; see "Maintenance").
+
+### Always gated, even on loopback
+
+**1.1: some endpoints require the owner credential ALWAYS, even on
+loopback.** This is a *separate, stricter* check from the loopback-vs-token
+rule above. Sixteen routes carry that always-on check, and these are all of
+them:
+
+- `GET /facts`, `GET /review`, and every verb on one existing fact by id:
+  `PATCH /facts/{id}`, `/facts/{id}/supersede`, `/facts/{id}/approve`,
+  `/facts/{id}/dismiss`, `DELETE /facts/{id}`
+- the two bulk ledger verbs: `POST /facts/quarantine`,
+  `POST /review/dismiss-all`
+- `POST /search`, `POST /consolidate`, `GET /jobs/{id}`
+- all four attachment routes: `GET /attachments`,
+  `GET /attachments/{id}/file`, `GET /attachments/{id}/preview`,
+  `DELETE /attachments/{id}`
+
+No other `/v1` route carries it. Two things sit outside that count without
+contradicting it. `GET /` is not on the list yet still varies by credential:
+an unauthenticated caller gets the locked page rather than the admin UI, and
+no 401. And the loopback-vs-token rule above is a separate gate that governs
+the whole surface.
+
+### Open routes
+
+Every other `/v1` route answers an unauthenticated loopback caller, governed
+only by the loopback-vs-token rule:
+
+- `/health`, `/disposable-identity`, `/backup`
+- `/ingest`, `/distill`, `POST /facts` to create
+- `/recall`, `GET /summary`
+- **`POST /summary/regenerate`**, which rebuilds the live profile
+- **all three `/summary/versions*` routes**, including the one that returns
+  a stored profile in full and the one that restores it over the live
+  profile
+- every `/viz/*` route
+
+The last two bullets are the ones a reader is most likely to expect gated.
+See "Owner admin token" below, and "Open on loopback, and what that means"
+at the end of it.
 
 ## Handshake
 
@@ -85,14 +98,15 @@ startup; `scripts/rebuild_fts.py` does the same for a live instance without a
 restart. A client seeing `fts_in_sync: false` should treat search results as
 unreliable until it flips back, not as an empty archive.
 `status`, `contract_version`, `db` and `capabilities` are contractual.
-`detail` is NOT: it repeats the entire internal health dict (sqlite version,
+`detail` is NOT. It carries the whole internal health dict for the admin
+page's health panel, and may change without a contract bump: sqlite version,
 journal mode, integrity, size, a facts breakdown of
 total/current/superseded/quarantined, message and conversation counts, an
-attachments block, last backup, backups kept, and an in-memory
-`dropped_by_reason` count of extraction-wall drops since the process started,
-e.g. `{"system-meta": 3, "builder-process": 11}`, reset on restart and never a
-record of *what* was dropped) for the admin page's health panel, and may
-change without a contract bump. Clients should read `db`, never `detail`.
+attachments block, last backup, and backups kept. It also carries
+`dropped_by_reason`, an in-memory count of extraction-wall drops since the
+process started (e.g. `{"system-meta": 3, "builder-process": 11}`). That
+count resets on restart and is never a record of *what* was dropped.
+Clients should read `db`, never `detail`.
 
 ## Owner admin token
 
@@ -115,8 +129,9 @@ ids/text/status, read the review queue, or search the raw transcripts with no
 credential at all; that would bypass the point of the opt-in admin MCP
 capability entirely.
 
-Three rules survive from earlier revisions of this design, and all are
-test-enforced:
+### Three rules, all test-enforced
+
+These survive from earlier revisions of this design:
 
 - **Unauthenticated pages never contain credentials.** `GET /` serves the
   real admin UI only to a caller who is ALREADY authenticated (a valid
@@ -126,12 +141,12 @@ test-enforced:
   or on first run for a recovery secret plus a new password (see "Owner
   password login" below); the admin token is never accepted there.
 - **Sessions are opaque server-side ids.** `POST /login` mints a fresh,
-  random, high-entropy session id (`secrets.token_urlsafe(32)`, never derived
-  from or equal to any client-supplied value, so there is no session
-  fixation) and records its expiry **server-side**, in
-  `app.state.admin_sessions` (in-memory; a restart clears it, so every
-  browser must re-authenticate after one, which is deliberate and keeps
-  sessions out of the ledger/DB entirely). The cookie carries ONLY that
+  random, high-entropy session id (`secrets.token_urlsafe(32)`) and records
+  its expiry **server-side**, in `app.state.admin_sessions`. The id is never
+  derived from or equal to any client-supplied value, so there is no session
+  fixation. That store is in-memory, so a restart clears it and every browser
+  re-authenticates: deliberate, and it keeps sessions out of the ledger and
+  the database entirely. The cookie carries ONLY that
   opaque id. A copy of the cookie is therefore a bounded, revocable
   capability: it expires (`app.state.admin_session_ttl`, 24h by default),
   and `POST /logout` deletes it from the server-side store, which
@@ -148,7 +163,9 @@ test-enforced:
   route, including the summary-version and `/viz/*` routes described under
   "Open on loopback, and what that means" at the end of this section.
 
-**Getting the token in the first place is always out-of-band, never HTTP:**
+### Getting the token
+
+Always out-of-band, never over HTTP:
 - If `MEMORY_AUTH_TOKEN` is configured (`.env` / `config.local.json` /
   environment), that's the token: **stable across restarts**, which is what a
   persistently-registered MCP client needs. The owner already knows it (they
@@ -159,7 +176,9 @@ test-enforced:
   session sharing the machine's filesystem/network has no route to another
   process's live terminal output.
 
-**Owner password login.** The everyday browser login is a durable
+### Owner password login
+
+The everyday browser login is a durable
 **password**, not the admin token, so an owner does not have to hunt the
 terminal for a token after every restart. The admin token keeps two roles: it
 is still the `Authorization: Bearer` credential (MCP/curl), and it is the
@@ -189,7 +208,9 @@ longer accepted as the everyday login.
   same recovery-gated proof, allowed at any time, replacing the verifier.
 - `POST /logout` revokes the session server-side and clears the cookie.
 
-**Passkey login (#27).** With a passkey enrolled, the lock screen offers it
+### Passkey login
+
+With a passkey enrolled, the lock screen offers it
 first and the password moves one click behind it; a successful assertion
 mints exactly the same opaque session as a password login. The password and
 recovery secret are unchanged. A passkey is bound to the web origin it was
@@ -204,7 +225,7 @@ origin (`127.0.0.1`) can never hold one.
 - `POST /webauthn/login/options` and `POST /webauthn/login` (lock-screen
   surface): challenge out, signed assertion in, verified against the
   enrolled public key with user verification (Touch ID / Face ID) required.
-  The options response discloses no credential ids — credentials are
+  The options response discloses no credential ids. Credentials are
   enrolled as discoverable, so the browser finds its own.
 - `GET /webauthn/credentials` and `DELETE /webauthn/credentials/{id}`
   (unlocked session or bearer): list and remove enrolled passkeys. Removal
@@ -213,7 +234,8 @@ origin (`127.0.0.1`) can never hold one.
 These endpoints are the browser admin UI surface (`include_in_schema=False`),
 not part of the versioned `/v1` contract, so `contract_version` is unchanged.
 
-**Runtime sequence for the opt-in admin MCP server**
+### Runtime sequence for the opt-in admin MCP server
+
 (`memory_service.mcp_admin_server`):
 1. Configure a stable token: put `MEMORY_AUTH_TOKEN=<random value>` in `.env`
    (or `config.local.json`).
@@ -292,8 +314,10 @@ later ingest of the same conversation, so a chat renamed in the client catches
 up here. It is the title `/search` hits carry back and the admin pages show;
 a client that never sends one leaves every conversation blank.
 
-`speaker` guest classes (additive, 2026-08-08, #31): beside `user` (the
-owner) and a bare model slug (`claude`), a message may carry `guest:<name>`
+### Guest speaker classes
+
+Additive, 2026-08-08. Beside `user` (the owner) and a bare model slug
+(`claude`), a message's `speaker` may carry `guest:<name>`
 for another, named human in the session (a multi-human voice session in
 room mode), or `guest:unknown` for a human turn whose voice diarization
 could not attribute confidently. `source_app` handling and conversation
@@ -320,10 +344,12 @@ pass:
   null) rather than pinned to whichever turn ended the mining window. In a
   guest-present window such a fact is still held for review, unchanged.
   When the miner supplies a missing binding on the corrective retry, that
-  answer is now checked against the turn it names — a turn sharing none of
+  answer is now checked against the turn it names: a turn sharing none of
   the fact's wording, or one no more plausible than a guest's turn in the
   same window, is refused and the fact stays held. A retry's guess about
   who spoke can no longer promote a guest's sentence into owner canon.
+
+### Attachments on ingest
 
 `attachments` (additive, 2026-07-11) is optional, per message. Files are part
 of the episodic record: bytes stored whole (content-addressed under
@@ -339,11 +365,15 @@ Limits: ≤5000 messages per call (more is a 413), ≤20 attachments per message
 history: storage itself is uncapped by design, so send a long backlog in
 batches rather than one giant POST.
 
+### Distill
+
 `POST /distill`: run the reflection pass (mining + walls) over un-mined ingested
 content for a conversation. Async.
 ```json
 {"source_app": "multi-model-chat", "conversation_id": "chat-123"}
 ```
+
+### Verbatim search
 
 `POST /search`: verbatim FTS over the episodic record. **Requires the owner
 credential (`Authorization: Bearer` or the admin session cookie), even on
@@ -390,6 +420,8 @@ proposing a revision), POST it with a non-`user` `origin_agent` (the authoring
 model's slug) and no trusted `source_app`; it lands in `GET /facts?status=quarantined`
 for the owner to `approve` or `dismiss`.
 
+### Reading the ledger
+
 `GET /facts?status=valid|superseded|quarantined|all&q=...&limit=...`: list/filter.
 **Requires the owner admin token, even on loopback** (see "Owner admin token" above).
 `status` defaults to `valid`; `q` is a substring match on content; `limit`
@@ -413,6 +445,8 @@ since 2026-07-11, `importance`; the human outranks the miner on how a fact ages.
 with a `detail` 422, not clamped**, so send a value in range rather than
 relying on the endpoint to fold it back. **Requires the owner admin token,
 even on loopback.**
+
+### Changing a fact's state
 
 `POST /facts/{id}/supersede`: `{"successor_id": 2}`; temporal validity, never delete.
 **Requires the owner admin token, even on loopback.**
@@ -443,12 +477,14 @@ messages); human-initiated only, never automated. Every erasure appends a
 content-free row (kind, refs, when - never content) to the `erasures` journal
 (#45). **Requires the owner admin token, even on loopback.**
 
+### The review queue
+
 `GET /review`: held-for-review queue. **Requires the owner admin token, even
 on loopback.**
 
 Each row is the whole fact row plus `source` (additive, 2026-08-12, contract
 version unchanged): the turn the fact was mined from, so the first question a
-reviewer has — who said this — is answered without leaving the queue.
+reviewer has, who said this, is answered without leaving the queue.
 ```json
 "source": {"message_id": 812, "speaker": "guest:Sam", "speaker_class": "guest",
            "created_at": 1754616000.0, "excerpt": "I hate coriander…",
@@ -467,7 +503,7 @@ clears a whole cause without ever sweeping rows the owner has not seen.
 `source` is `null` whenever the fact names no source message: an external
 (`mcp:*`) write, a fact saved by hand, or a mined fact that could not be tied
 to a single turn (see the guest-speaker notes above). It is never filled in
-with a nearby turn — "Sam said this" and "no one knows who said this" are
+with a nearby turn. "Sam said this" and "no one knows who said this" are
 different decisions, and a queue that blurs them is worse than one that stays
 silent. `excerpt` is the first 400 characters of the message's own content
 (attachment text is not included); `truncated` says whether more exists.
@@ -517,6 +553,8 @@ The MCP adapter can render its `[SUPERSEDED …]` flag because it calls
 `recall.recall()` in-process and sees the whole row; an HTTP caller that
 needs lifecycle state must use the owner-gated `GET /facts` instead.
 
+### Summary
+
 `GET /summary` → `{"summary": "...", "generated_at": "...", "source_fact_ids": [..],
 "word_count": 1980, "word_budget": 2000, "provenance": [{"id": 12,
 "origin_agent": "user", "source": "user", "tag": "direct"}, ...]}`
@@ -528,15 +566,19 @@ pass, never truncation.)
 summary (same set as `source_fact_ids`), carrying that fact's **raw**
 `origin_agent` and `source` columns plus a mechanically-derived `tag`; this
 is how a client checks per-claim origin *without* trusting unlabelled prose
-for attribution. `tag` is one of: `direct` (`origin_agent == "user"`; the
-owner saved it themselves), `mined` (`source == "chat"`; the miner distilled
-it from a multi-turn conversation, and **no single turn or speaker is
-recorded**, so the summary prose must never attribute a mined claim to "the
-user" or any named participant), or, for anything else, the raw
-`origin_agent` verbatim (a participant's own slug, an approved `mcp:<client>`
-write, etc.); this repo deliberately does not flatten that remainder into an
-invented category like "curated", since that would claim more certainty
-about authorship than the record supports. The prose itself is instructed
+for attribution. `tag` is one of:
+
+- `direct` (`origin_agent == "user"`): the owner saved it themselves.
+- `mined` (`source == "chat"`): the miner distilled it from a multi-turn
+  conversation. **No single turn or speaker is recorded**, so the summary
+  prose must never attribute a mined claim to "the user" or any named
+  participant.
+- anything else: the raw `origin_agent` verbatim, such as a participant's
+  own slug or an approved `mcp:<client>` write.
+
+That remainder is deliberately not flattened into an invented category like
+"curated", which would claim more certainty about authorship than the record
+supports. The prose itself is instructed
 the same way (mention provenance only when material, never invent a speaker
 for a `mined` or unrecognised-tag entry) but `provenance` is the
 mechanically-checkable source of truth; read it instead of parsing the
@@ -561,12 +603,16 @@ can start an open async operation but cannot poll its result.
 `result` is the only place an async operation's output lands, and it stays
 `null` until `status` is `ok`; its shape depends on `kind`. A distill
 returns mining counts: `{"added", "quarantined"}` always, plus up to three
-only-when-nonzero keys: `deduped` (a re-mine was collapsed),
-`refused_supersede` (a proposal was refused because the new fact's event
-date is more than a day older than its target's; old claims file as dated
-history and never retire newer truth), and `deferred_supersede`
-(a held-for-review fact proposed a replacement; quarantine can't alter
-canon, so the proposal waits for human review). Or, if another
+only-when-nonzero keys:
+
+- `deduped`: a re-mine was collapsed.
+- `refused_supersede`: a proposal was refused because the new fact's event
+  date is more than a day older than its target's. Old claims file as dated
+  history and never retire newer truth.
+- `deferred_supersede`: a held-for-review fact proposed a replacement.
+  Quarantine cannot alter canon, so the proposal waits for human review.
+
+Or, if another
 distill of the same conversation was already in flight, `{"added": 0,
 "quarantined": 0, "skipped_locked": true}` and nothing was mined. Read
 the extra keys with a default rather than indexing them; on the ordinary
@@ -601,12 +647,15 @@ The invariant is a claim about the viz endpoints alone. The attachment and
 summary-version endpoints in this same section deliberately DO return
 content, because showing you your own files and profile text is their whole
 job. Note the difference in who may ask: the attachment routes require the
-owner credential, the summary-version routes do not (see "Open on loopback").
+owner credential, the summary-version routes do not (see "Open on loopback, and what
+that means").
 
 `GET /` (admin page) · `GET /math` (the Mathematics page).
 All four attachment routes below require the owner credential, on loopback
 too, like the exact-row fact routes (2026-07-25). They return fact content,
 message bodies and document text, so a loopback-only rule was never enough.
+
+### Attachments
 
 `GET /v1/attachments`: every stored file with its conversation context
 (`limit` defaults to 200, maximum 1000).
@@ -619,6 +668,8 @@ from that conversation.
 human-initiated via the danger zone, the only delete path; content-addressed
 bytes are unlinked only when no other row references them. Journals to
 `erasures` like every eraser.
+
+### Messages
 
 `GET /v1/messages/resolve?source_app=&conversation=&message=`: maps a
 producer's ref (how crossband names a message: source app, conversation
@@ -693,6 +744,9 @@ Anchor routes answer `410 gone` afterwards; the record itself stays
 listed so syncing apps learn to delete their copies.
 The three summary-version routes below, unlike the attachment routes above,
 are **NOT** gated: they answer an unauthenticated loopback caller.
+
+### Summary versions
+
 `GET /v1/summary/versions`: every generated profile, newest first (metadata
 only; append-only history, so regeneration never destroys a version).
 `GET /v1/summary/versions/{id}`: one version with its full text. Open on
@@ -700,6 +754,9 @@ loopback, so any local process can read any stored profile in full.
 `POST /v1/summary/versions/{id}/restore`: make that version current again by
 APPENDING a new version row (`restored_from` set); history is never rewritten.
 Open on loopback, so any local process can change which profile is live.
+
+### Visualisation routes
+
 `GET /v1/viz/decay`: every live card's (age, importance, score) + formula constants.
 `GET /v1/viz/embeddings`: cached 3D PCA of up to the newest 2,500 embedded
 cards (`SAMPLE_CAP` in `viz.py`; the projection's Gram matrix costs O(n²)
@@ -715,24 +772,32 @@ single scene 2026-07-20; all additive). **Self-sufficient**: returns
 `{"status": "computing"}` and kicks off the one-time PCA projection build itself
 when cold (no separate `/embeddings` call needed), then serves the scene. Geometry
 only, showing **alive** facts (non-superseded, non-quarantined) as they are now:
-`nodes` (id, **3D** coords `x,y,z`, importance, freshness score, cluster index),
-`clouds` (biomes from deterministic **k-means on the 3D coords**, bounded count
-~sqrt(n/2) clamped to [6,14]; each carries a 3D centroid `cx,cy,cz`, the 6 unique
-covariance entries `cov=[xx,yy,zz,xy,xz,yz]` (so the client renders a translucent
-volumetric ellipsoid via Σ₂=JΣJᵀ rather than a flat hull), a `spread` radius, mean
-`freshness`, density `size`, and a palette INDEX that only distinguishes a biome
-from its neighbours, never a fixed topic→colour map),
+
+- `nodes`: id, **3D** coords `x,y,z`, importance, freshness score, cluster
+  index.
+- `clouds`: biomes from deterministic **k-means on the 3D coords**, bounded
+  count ~sqrt(n/2) clamped to [6,14]. Each carries a 3D centroid `cx,cy,cz`,
+  the 6 unique covariance entries `cov=[xx,yy,zz,xy,xz,yz]`, a `spread`
+  radius, mean `freshness`, density `size`, and a palette index. The
+  covariance entries let the client render a translucent volumetric
+  ellipsoid via Σ₂=JΣJᵀ rather than a flat hull. The palette index only
+  distinguishes a biome from its neighbours; it is never a fixed
+  topic→colour map.
 `edges` (co-occurrence: facts recalled together in the access log, weighted),
 `sediment` (per current fact, the ids/dates/importances of the facts it
 superseded), `summary_ids` (current summary membership, for the dot ring),
 `sampled` (true when the 2,500-card projection cap bit; see
 `/v1/viz/embeddings` above), and `notes` naming any layer the current ledger
-can't yet fill. (The admin UI now drives "The life of your memory" entirely
+can't yet fill. The admin UI now drives "The life of your memory" entirely
 from this endpoint; `/v1/viz/embeddings` above is retained but no longer the
-UI's source.)
+UI's source.
+
+### Recall trace and the access log
+
 `POST /v1/viz/recall_trace`: `{"query", "limit"}` → the recall pipeline,
-instrumented: per-card score components and fate (kept / collapsed / over / dim),
-plus lifecycle + dup edges so the client can replay the answer as of any past time.
+instrumented. Per-card score components and fate (kept / collapsed / over /
+dim), plus lifecycle and dup edges, so the client can replay the answer as of
+any past time.
 Kept in lockstep with `/v1/recall` by test. `limit` is silently clamped to 20
 because the endpoint exists to draw a diagram rather than to export data.
 `GET /v1/viz/recalls?after=<ts>`: lookup events from the persistent access log:
@@ -787,12 +852,13 @@ consuming model must be able to see the age without a second call.
 
 `memory_service/mcp_admin_server.py` is a **second** MCP server, not part of the
 four tools above and not registered by default. It exists for a session doing
-ledger *remediation* (e.g. confirming a suspected mis-mined fact) that needs exact
-rows, not semantic recall: `search_facts(query, status)` and `review_queue(query)`,
-thin GET-only wrappers over `GET /v1/facts` and `GET /v1/review` above, which,
-as of 1.1, are genuinely token-gated server-side (see "Owner admin token"), so
-this wrapper's own token requirement is enforced by the API itself rather than
-being merely a client-side convention. Differences from the four model-facing
+ledger *remediation*, such as confirming a suspected mis-mined fact, which
+needs exact rows rather than semantic recall. Two tools:
+`search_facts(query, status)` and `review_queue(query)`, thin GET-only
+wrappers over `GET /v1/facts` and `GET /v1/review` above. As of 1.1 both are
+genuinely token-gated server-side (see "Owner admin token"), so this
+wrapper's token requirement is enforced by the API rather than being a
+client-side convention. Differences from the four model-facing
 tools:
 - Requires `Authorization: Bearer <MEMORY_AUTH_TOKEN>` matching the running
   service's own admin token, even against loopback (unlike the base API's

--- a/docs/MEMORY_DESIGN.md
+++ b/docs/MEMORY_DESIGN.md
@@ -118,7 +118,9 @@ The ledger still has every fact, and `recall_memory` can still fetch anything
 on demand; a card missing from today's profile has merely been out-selected
 and remains retrievable.
 
-**The word budget is enforced honestly.** The profile is written to a word
+#### The word budget
+
+The profile is written to a word
 budget (default 2000, `memory_summary_words`) with a per-section ceiling, and
 the budget is enforced by *rewriting*, never truncation: if the draft
 overshoots by more than ~20%, it gets one "compress to budget" pass.
@@ -132,7 +134,9 @@ an append-only version history, and any earlier version can be restored from
 the admin page if a rebuild reads worse than what it replaced; this is the
 same never-delete standard the ledger holds facts to.
 
-**The profile's topics morph with your life.** The spine is fixed (Identity,
+#### Topics morph with your life
+
+The spine is fixed (Identity,
 Preferences, Relationships & People at the stable top; Goals & Active
 Threads, Recent Changes at the volatile bottom) because that stable→volatile
 separation is the load-bearing structure. But the middle sections are named

--- a/docs/MEMORY_DESIGN.md
+++ b/docs/MEMORY_DESIGN.md
@@ -1,7 +1,7 @@
-# How memory works, and how we're refining it
+# How memory works
 
-Plain-English first, then the limits and the plan. For the cited research behind the
-refinements see [REFERENCES.md](REFERENCES.md); for the wire contract see
+The model in plain English, then what is capped and what is not. The cited
+research is in [REFERENCES.md](REFERENCES.md), the wire contract in
 [API.md](API.md). No real personal data appears here; examples are invented.
 
 ## Three layers, three jobs
@@ -10,40 +10,38 @@ refinements see [REFERENCES.md](REFERENCES.md); for the wire contract see
    real date and who said it. Never edited. Ground truth. Searchable verbatim.
    Files that travelled with messages (pasted documents, PDFs, images) are part
    of the tapes too: stored whole on disk, their text extracted where possible so
-   search and the note-taker see it. A memory that silently dropped what you
+   search and the miner see it. A memory that silently dropped what you
    pasted wouldn't be ground truth.
 2. **The cards** (the ledger): short durable facts distilled from the tapes, one
    fact per card. **Append-only**: a card is never thrown away; when something
    changes, the old card is flipped face-down (*superseded*) and kept as history.
-3. **The cheat-sheet** (the summary): a one-page profile built from the face-up
-   cards, handed to the models at the start of every chat so they know you without a
+3. **The profile** (the summary): one page built from the face-up cards, handed to the models at the start of every chat so they know you without a
    lookup. It is a *cache* over the cards, and the cards remain the source of
    truth.
 
-A cheap "note-taker" model reads each conversation on the way out and writes cards; a
-"bouncer" (the four extraction walls) checks each card before it's trusted.
+A cheap miner model reads each conversation on the way out and writes cards.
+The four extraction walls check each card before it is trusted.
 
-Alongside the three layers sits **the visitor book** (the access log):
+Alongside the three layers sits **the access log**:
 every deep recall, history search and summary fetch, from the chat app
 and from the model-facing MCP tools alike, appends one row saying when it
 happened and where the request came from. How much detail the row carries
 depends on the kind: a recall records the question and which cards came
 back, with their scores; a history search records the question and how
 many messages matched (the results are tapes, not cards); a summary fetch
-records only that the cheat-sheet was read. It changes nothing about
+records only that the profile was read. It changes nothing about
 what's remembered; it's how the system can later show you your memory
 being *used* (the Mathematics page's live view reads it) and, eventually,
 let often-recalled cards resist forgetting (reinforce-on-reuse).
 Browsing the ledger *directly* (the admin page's Ledger table, or the
-read-only admin MCP tools) is not logged today; the visitor book covers
+read-only admin MCP tools) is not logged today; the access log covers
 lookups made on a model's behalf rather than your own inspection.
 
 ## What is capped, and what is not
 
-This is the part worth being precise about, because "cap" means several
-different things here, and **only two of them are real limits**: how much
-of one long message the note-taker reads, and how many cards the
-cheat-sheet folds.
+"Cap" means several different things here and **only two of them are real
+limits**: how much of one long message the miner reads, and how many cards
+the profile folds.
 
 ### Storage: never capped
 The ledger holds unlimited cards. Nothing is ever dropped, deleted, or aged out by
@@ -51,8 +49,8 @@ the software; a fact only ever becomes *superseded* or *quarantined* (both
 reversible, both kept). The database growing is fine: invalid cards cost nothing
 because they're simply not shown to the models.
 
-### What the note-taker reads: bounded per message (a real limit)
-The note-taker reads a *bounded view* of each message: the message plus
+### What the miner reads: bounded per message (a real limit)
+The miner reads a *bounded view* of each message: the message plus
 any text extracted from the files that travelled with it, truncated to
 **20,000 characters** for extraction only. So a 200,000-character pasted
 document contributes its first 20,000 characters to the cards; the tapes
@@ -60,8 +58,7 @@ still keep every byte, and a history search still finds any word of it,
 including inside attached files. Long or long-idle conversations are mined
 in windows of **120 messages / ~350,000 characters**, each window advancing a
 watermark so an interrupted run resumes where it stopped instead of
-re-reading (or overflowing) what it already mined. The honest reason for
-both bounds: what the note-taker reads has to fit in one model call.
+re-reading (or overflowing) what it already mined. Both bounds exist because what the miner reads has to fit in one model call.
 
 ### Reading the ledger yourself (the admin UI): paged rather than capped
 The ledger table fetches a page at a time (200 rows) for browser performance, then
@@ -81,7 +78,7 @@ deliberate: the model wants the few cards that bear on the question rather than
 1,000 facts dumped into a tool result, so ranking plus a small limit is the
 right behaviour here.
 
-### The summary (the always-on cheat-sheet): folds ~500 cards (a real limit)
+### The profile (always on): folds ~500 cards (a real limit)
 The profile is rebuilt by *folding*: one pass in which the selected cards
 are read together and rewritten into the one-page profile. The fold is fed
 two pools of currently-valid cards: **up to 200 durable cards + up to 300
@@ -91,7 +88,7 @@ competition; see below).
 Below ~500 facts, everything you have is represented: the two pools together
 hold more cards than the ledger does, so nothing has to be left out. Past
 that the fold hits its ceiling and cards start being left out of the
-cheat-sheet, out-selected on merit. So *which* cards make it matters. Selection (`weighting.py`, mechanisms cited
+profile, out-selected on merit. So *which* cards make it matters. Selection (`weighting.py`, mechanisms cited
 in [REFERENCES.md](REFERENCES.md)) is:
 
 - **Recency × importance**, decaying on the card's true `event_date` (never
@@ -143,8 +140,7 @@ separation is the load-bearing structure. But the middle sections are named
 by the model from what your facts actually cluster around: a hobby, a
 project, a career thread. Topics appear when they earn their space and
 dissolve as their facts fade; the forgetting curve becomes visible in the
-document's own table of contents. (Research lineage and the honest caveats
-are in [REFERENCES.md](REFERENCES.md). This began behind a config flag as a
+document's own table of contents. (Research lineage and the caveats are in [REFERENCES.md](REFERENCES.md). This began behind a config flag as a
 reversible experiment and later became the only layout; there is no
 fixed-headings mode to switch back to.)
 
@@ -155,27 +151,17 @@ job routed to a stronger model
 deserves space is worth paying for; the cheap miner keeps the high-volume
 extraction work.
 
-## How we're refining it further
+## What is planned
 
-The direction (researched and cited in [REFERENCES.md](REFERENCES.md); future
-work is tracked in the public issues):
+Per-section fold budgets, half-life tuning on real data, incremental rebuild,
+and consolidation v2 (clustered merge proposals you approve). The research
+behind each is in [REFERENCES.md](REFERENCES.md); the work itself is tracked
+in the public issues.
 
-- **Per-section budgets** so each profile section has its own slice of the fold,
-  plus dynamic reallocation when one section runs hot.
-- **Half-life tuning**: the 30-day base constant is a researched starting
-  point; real-world feel decides where it lands.
-- **Incremental rebuild**: fold only new/changed cards instead of re-reading all 500
-  every time, so the cheat-sheet stays cheap as the ledger grows.
-- **Consolidation v2**: cluster related cards and propose merges/supersessions
-  (advisory; you still approve), so the ledger stays tidy and the 500 budget spends
-  on distinct facts, not near-duplicates. Its clusters also unlock a saturating
-  per-topic frequency boost (an active thread surfaces; a noisy topic can't
-  monopolise).
-
-Underneath all of it, one principle: **the ledger is the system of record; the
-summary is a fast cache over it.** The refinements make the cache smarter without
-ever making it the source of truth, so a two-year-old stable fact is always still
-recallable even if it's not in today's profile.
+Underneath all of it, one principle: **the ledger is the system of record and
+the profile is a fast cache over it.** A refinement makes the cache smarter
+without ever making it the source of truth, so a two-year-old stable fact
+stays recallable even when it is not in today's profile.
 
 ## Why SQLite
 
@@ -190,7 +176,7 @@ rather than a database swap. And because clients only ever speak the versioned
 HTTP contract, never the database itself, the choice is an implementation
 detail that could be replaced without breaking anyone.
 
-## Current limitations, stated plainly
+## Current limitations
 - Summary selection is salience-weighted but not yet section-budgeted (the word
   budget has per-section caps; the *fold selection* doesn't yet); the decay
   half-life is untuned.

--- a/docs/MEMORY_INTEGRITY.md
+++ b/docs/MEMORY_INTEGRITY.md
@@ -66,10 +66,10 @@ summary, flagged low-confidence), never silently trusted. A human clears the que
 
 4. **System-meta (a drop rather than a quarantine)**: a "fact" about this memory
    system's own machinery or the AI tooling itself ("the memory ledger quarantined
-   100 facts", "the grounding wall over-flagged", "PID 4321") is not biography about
-   the user at all, so there is nothing to review; quarantining it only floods the
-   queue when a conversation happens to be *about the memory system*, a failure mode
-   this project hit in practice. Such lines are never extracted. The filter is
+   100 facts", "the grounding wall over-flagged", "PID 4321") is not biography
+   about the user at all, so there is nothing to review. Quarantining it only
+   floods the queue when a conversation happens to be *about the memory system*,
+   a failure mode this project hit in practice. Such lines are never extracted. The filter is
    deliberately narrow: it matches system/AI-tooling *mechanics* vocabulary only,
    never generic verbs ("deployed", "committed") or product names a real
    career/project fact might carry; those stay eligible and are judged by the three
@@ -114,10 +114,10 @@ walls make the *write* safe instead. This trade-off is deliberate.
   this, only proper nouns were checked, so a fact could carry a resolved date
   nobody wrote and still read as high-confidence.
 - **A card's source turn is recorded only when it is real.** A mined card
-  points at one message only when the extractor actually named that message,
-  and when the extractor has to be re-asked for a binding it omitted, the turn
-  it names must share the card's own wording — and must be at least as
-  plausible a source as any other speaker's turn in the same window. A card
+  points at one message only when the extractor actually named that message.
+  When the extractor has to be re-asked for a binding it omitted, the turn it
+  names must share the card's own wording, and must be at least as plausible
+  a source as any other speaker's turn in the same window. A card
   nothing could be tied to is stored *unbound*, and the review queue says so,
   rather than being attributed to whichever message happened to end the mining
   window. Wrong provenance is quieter than a wrong fact and harder to unpick:
@@ -131,7 +131,9 @@ walls make the *write* safe instead. This trade-off is deliberate.
   like five confirmations. The match is on exact wording, which is what that
   crash-retry case needs; a reworded re-mine is a different problem (see below).
 
-**Supersession direction is enforced.** The miner may propose that a new
+### Supersession direction is enforced
+
+The miner may propose that a new
 fact retires a listed one, but two guards bound what a proposal can actually do.
 A fact whose grounded event date is more than a day older than its target's
 cannot supersede it, so mining imported or re-mined history files old claims
@@ -141,7 +143,7 @@ deferred, and today surfaces as a count in the distill result, for the human
 pass to apply or ignore. Both guards bind the automated path only; the owner's
 supersede action in review stays unrestricted.
 
-**Honest limitations (tracked in the public issues):**
+### Limitations (tracked in the public issues)
 - The walls are high-recall *detection* rather than perfect prevention: they flag
   for review (~12% false-positive on genuinely valid facts in the original tuning);
   they don't hard-reject. A stricter semantic gate is planned.

--- a/docs/MEMORY_INTEGRITY.md
+++ b/docs/MEMORY_INTEGRITY.md
@@ -18,10 +18,10 @@ Meet "Sam." Here's a three-step poisoning, none of it done on purpose by the use
 
 2. **The model launders the fiction into a claim.** Later Sam asks a model *"what do
    you know about me?"* The model, summarising loosely, writes *"Sam is based in
-   Metropolis."* The note-taker mines that assistant summary and files a card:
+   Metropolis."* The miner reads that assistant summary and files a card:
    *Sam lives in Metropolis.*
 
-3. **The lie multiplies.** The note-taker is shown the current ledger (it has to be;
+3. **The lie multiplies.** The miner is shown the current ledger (it has to be;
    that's how it de-dupes and detects supersessions). Now *Metropolis* looks
    canonical, so it gets restated and reinforced, stamped onto home-renovation chats,
    scheduling chats, chats that never mentioned any city at all.
@@ -76,9 +76,9 @@ summary, flagged low-confidence), never silently trusted. A human clears the que
    quarantine walls, so at worst they land in review, never silently dropped. The
    verbatim message always survives in the episodic record, so nothing is lost.
 
-## Why the note-taker still sees the ledger
+## Why the miner still sees the ledger
 
-It would be tempting to "fix" contamination by hiding the ledger from the note-taker.
+It would be tempting to "fix" contamination by hiding the ledger from the miner.
 That breaks de-duplication and supersession detection: the miner could no longer tell
 "already known" from "new," or "this updates that." The ledger stays visible; the
 walls make the *write* safe instead. This trade-off is deliberate.
@@ -118,9 +118,7 @@ walls make the *write* safe instead. This trade-off is deliberate.
   When the extractor has to be re-asked for a binding it omitted, the turn it
   names must share the card's own wording, and must be at least as plausible
   a source as any other speaker's turn in the same window. A card
-  nothing could be tied to is stored *unbound*, and the review queue says so,
-  rather than being attributed to whichever message happened to end the mining
-  window. Wrong provenance is quieter than a wrong fact and harder to unpick:
+  nothing could be tied to is stored *unbound*, and the review queue says so. Wrong provenance is quieter than a wrong fact and harder to unpick:
   it makes a guest's sentence, or a synthesis of several turns, read like
   something the owner said.
 - **A re-mine can't duplicate a card that's still current.** Two mining passes over

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -1,9 +1,10 @@
 # References
 
-The memory design implements mechanisms from published research. Credit where it's
-due, and honesty about what we verified: findings below are marked **implemented**,
-**planned**, or **refuted** (claims our own adversarial verification pass could not
-support; we use the mechanism but not the claimed numbers).
+The memory design implements mechanisms from published research. Credit where it is
+due, and what was verified: findings below are marked **implemented**,
+**planned**, or **refuted**. Refuted means an adversarial verification pass
+here could not support the claim, so the mechanism is used but the published
+numbers are not.
 
 ## Implemented
 
@@ -24,8 +25,7 @@ support; we use the mechanism but not the claimed numbers).
 - **Recency × importance summary selection** (`weighting.py`): facts are scored
   `importance × exp(−age/half_life)` on the fact's true **event_date**, so
   bulk-imported old facts sort as old whatever their insertion order.
-  *Generative Agents (recency · importance; poignancy scoring; we drop the
-  relevance term, since a query-less summary fold has no query)*
+  *Generative Agents (recency · importance; poignancy scoring; the relevance term is dropped, since a query-less summary fold has no query)*
   ([arXiv 2304.03442](https://ar5iv.labs.arxiv.org/html/2304.03442)); decay form
   from *MemoryBank* `R = e^(−t/S)`.
 - **LLM-assigned 1–9 importance at extraction** (10 is owner-only; see the
@@ -33,7 +33,7 @@ support; we use the mechanism but not the claimed numbers).
   caveat). *Generative Agents.*
 - **Importance-adaptive decay**: half-life stretches ~4× from importance 1 to
   9 (22.5d → 82.5d), so life-defining facts outlive mundane ones without
-  hiding history. Above the stretch sits a **permanence tier of our own**:
+  hiding history. Above the stretch sits a **permanence tier added here**:
   importance 10 is owner-only and pinned, with an infinite half-life and an
   unconditional place in the profile's durable pool, exempt from its 200-slot
   competition. Over a years-long horizon every finite multiplier reaches zero,
@@ -82,11 +82,11 @@ support; we use the mechanism but not the claimed numbers).
 - *WMR formalisation* (Frontiers in Psychology)
   ([PMC12092450](https://pmc.ncbi.nlm.nih.gov/articles/PMC12092450/))
 
-## Refuted in our verification (mechanisms kept, numbers rejected)
+## Refuted in verification here (mechanisms kept, numbers rejected)
 
 - "Selective forgetting improves long-term recall (FadeMem beats Mem0/MemGPT on
   LoCoMo, 82% retention)": failed 0–3 in adversarial review; single vendor
-  simulation. We use FadeMem's *decay/frequency mechanisms*, not its benchmarks.
+  simulation. FadeMem's *decay and frequency mechanisms* are used; its benchmarks are not.
 - "MemoryBank ties decay to access/importance, dropping low-importance old items":
   overstated versus the primary text (1–2).
 - "Full retrievable history beats a lossy summary (32%→92%)": only partially

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,30 +15,33 @@ messages, attachments, or the access log; tests grep the source for
 forbidden statements as well as exercising behaviour. Supersession,
 quarantine, and dismissal round-trip reversibly. Summary regenerations
 append to a restorable history. The only deletes anywhere are the three
-human erasers on the admin surface (fact, file, message - the message
-one is #45, closing crossband#106's loop): `test_message_erase.py`
-proves the erase is owner-gated and single-row, search and health stay
-honest afterwards, live facts mined from an erased message resurface
-for review instead of vanishing, attachments are counted not cascaded,
-and every eraser journals a content-free `erasures` row - what was
-erased is gone, that it was erased is not.
+human erasers on the admin surface: fact, file, and message.
+`test_message_erase.py` pins the message one. The erase is owner-gated
+and single-row; search and health stay accurate afterwards; live facts
+mined from an erased message resurface for review instead of vanishing;
+attachments are counted, not cascaded. Every eraser journals a
+content-free `erasures` row, so what was erased is gone and that it was
+erased is not.
 
-**Person records (#33).** The wire identity (contract 1.2,
-`test_identity_wire.py`): `speaker_identity` stores verbatim and absent
-means 1.1 behaviour exactly; facts bind per the owner's policy
-(introduced/owner-correction always, voice-match at 0.8+, weaker never);
-merged slugs resolve to their winner, forgotten slugs bind nothing, and
-binding never changes whether a fact is held. Admin surface and base: The admin surface renames (owner-set, clients
-can't undo), merges (aliases, clips and fact links re-point; supersede
-not rewrite; refused on forgotten sides), moves and deletes single clips
-(moves collapse onto duplicates; deletes journal and unlink bytes) - all
-owner-gated, all in `test_person_records.py`. And the slice-1 base: Owner-set names survive client updates; an
-alias can never be reassigned to a different person; a model speaker
-label can never become a person; clips are content-addressed and
-owner-only on disk; sync includes forgotten marks; forget deletes the
-audio (journalled content-free), moves the person's approved facts back
-into review as one group and leaves held facts alone; every route
-refuses callers without the owner token (`test_person_records.py`).
+**Person records.** Owner-set names survive client updates. An alias can
+never be reassigned to a different person, and a model speaker label can
+never become a person. Clips are content-addressed and owner-only on disk,
+and sync includes forgotten marks. Forget deletes the audio (journalled
+content-free), moves the person's approved facts back into review as one
+group, and leaves held facts alone.
+
+The admin surface is pinned the same way, all of it owner-gated. A rename is
+owner-set and clients cannot undo it. A merge re-points aliases, clips and
+fact links, supersedes rather than rewrites, and is refused when either side
+is forgotten. Moving a clip collapses it onto a duplicate; deleting one
+journals the erasure and unlinks the bytes. Every route refuses callers
+without the owner token (`test_person_records.py`).
+
+**Wire identity (contract 1.2).** `speaker_identity` stores verbatim, and an
+absent field means 1.1 behaviour exactly. Facts bind per the owner's policy:
+introduced and owner-correction always, voice-match at 0.8+, weaker never.
+Merged slugs resolve to their winner, forgotten slugs bind nothing, and
+binding never changes whether a fact is held (`test_identity_wire.py`).
 
 **Extraction walls.** Ungrounded names quarantine. Ungrounded or
 relative dates never mint an event date; a missing year comes from the

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -142,12 +142,14 @@ Set `mirror_dir` to a folder inside iCloud Drive/Dropbox/OneDrive and every
 snapshot is copied off-machine automatically. This is strongly recommended,
 because the database holds your accumulated memory.
 
-**`auth_token`** is one secret with three jobs: (1) proof that you're the
-owner when you set or reset your admin password, (2) the
-`Authorization: Bearer` credential for machine callers (MCP servers
-such as the optional `membro-admin`, or curl), and (3) the thing that
-lets the service be served beyond localhost at all: with no configured
-value it refuses to bind a non-loopback host. Leaving it unset does
+**`auth_token`** is one secret with three jobs:
+
+1. Proof that you're the owner when you set or reset your admin password.
+2. The `Authorization: Bearer` credential for machine callers: MCP servers
+   such as the optional `membro-admin`, or curl.
+3. The thing that lets the service be served beyond localhost at all. With
+   no configured value it refuses to bind a non-loopback host.
+ Leaving it unset does
 **not** mean no secret exists: the service mints a fresh random one at
 every start and prints it to the terminal that ran `./start.sh`. Set a
 stable value in `.env` or `config.local.json` if you register the
@@ -155,7 +157,9 @@ stable value in `.env` or `config.local.json` if you register the
 secret changing on every restart. An auto-minted token still only works
 locally; remote serving needs a configured one.
 
-**Logging in.** The exact-row parts of the ledger always require an
+### Logging in
+
+The exact-row parts of the ledger always require an
 owner credential, even on loopback, so another process sharing
 127.0.0.1 can't read or edit those. That covers raw facts, the review
 queue, every action on a single fact (edit, supersede, approve,
@@ -187,15 +191,17 @@ in [API.md](API.md), the threat model and its honest limits in
 [SECURITY.md](../SECURITY.md), and the first-run walkthrough in
 [README.md](../README.md).
 
-**Remote access over your tailnet.** `MEMORY_TAILSCALE_SERVE=1`
+### Remote access over your tailnet
+
+`MEMORY_TAILSCALE_SERVE=1`
 in `.env` makes `start.sh` run `scripts/tailscale-serve.sh` at every startup,
 which maps this loopback service onto its own HTTPS port on your OWN
 Tailscale tailnet (`MEMORY_TAILSCALE_PORT`, default `8443`) via `tailscale
 serve`; never `tailscale funnel`, never a public port (see SECURITY.md's
 trust boundary). It uses a dedicated port rather than a path under the
-tailnet root on purpose: the admin UI links absolute paths (`/math`,
+tailnet root on purpose. The admin UI links absolute paths (`/math`,
 `/v1/…`), which under a `/membro` prefix would resolve to the root and hit
-whatever else is served there; on a machine also serving the chat client,
+whatever else is served there. On a machine also serving the chat client,
 that is a different application entirely. To actually sign in from a browser
 you must ALSO name that hostname in `MEMORY_TRUSTED_HOSTS`, or the request
 is refused by design.

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -1,10 +1,10 @@
 # Tuning: every knob, what it does, and why you'd turn it
 
-This service works out of the box with no tuning at all. But memory is
-personal, and the defaults are best guesses rather than laws; this page lists
-everything you can change, in plain English, with the reasoning behind each
-default. It is written to be pasted at an AI assistant ("help me set this up
-for my situation") or followed unaided.
+This service works out of the box with no tuning at all. Memory is personal
+though, and the defaults are best guesses rather than laws. Every setting you
+can change is listed here with the reasoning behind its default. Paste this
+page at an AI assistant ("help me set this up for my situation") or follow it
+unaided.
 
 ## How to change a setting
 
@@ -53,15 +53,13 @@ biography. The admin page shows actual words next to budget.
 stronger model than the fact miner. Any Anthropic (`claude-*`) or OpenAI
 model name works; the needed API key must be set.
 
-**The profile's headings are not a setting** (they used to be). The profile
-keeps a fixed spine (Identity, Preferences, Relationships & People at the
-top; Goals & Active Threads, Recent Changes at the bottom) and the model
-names the two to five middle sections from what your facts actually cluster
-around ("Pottery", "The garden build"…). Topics appear when they earn space
-and dissolve as they fade; why the spine is fixed is in
-[MEMORY_DESIGN.md](MEMORY_DESIGN.md). This ran behind a `summary_emergent_topics`
-flag from 2026-07-09 and graduated on 2026-07-26, so there is no fixed-headings
-mode any more; an old value left in your config is simply ignored.
+**The profile's headings are not a setting.** The profile keeps a fixed spine
+(Identity, Preferences, Relationships & People at the top; Goals & Active
+Threads, Recent Changes at the bottom). The model names the two to five middle
+sections from what your facts actually cluster around ("Pottery", "The garden
+build"…). Topics appear when they earn space and dissolve as they fade. Why
+the spine is fixed is in [MEMORY_DESIGN.md](MEMORY_DESIGN.md). A
+`summary_emergent_topics` value left in your config is ignored.
 
 **Importance and permanence.** The miner scores the facts it extracts
 from conversations 1–9: how much a fact matters to understanding you
@@ -118,7 +116,7 @@ you can watch them act on your real data. One consequence worth knowing
 before you go looking for a knob: a recall can come back with fewer
 facts than the limit asked for. Cards that clear neither the similarity
 floor nor a word from the query never enter the ranking, and
-near-duplicates collapse after it; returning fewer honest cards is
+near-duplicates collapse after it; returning fewer accurate cards is
 preferred to padding an answer with noise. If live use convinces you one
 of these constants is wrong, that's a bug report we want.
 
@@ -187,7 +185,7 @@ use:
 
 Your password is stored only as a salted scrypt verifier, never in a
 reversible form, and never handed back to the browser. The endpoints are
-in [API.md](API.md), the threat model and its honest limits in
+in [API.md](API.md), the threat model and its limits in
 [SECURITY.md](../SECURITY.md), and the first-run walkthrough in
 [README.md](../README.md).
 
@@ -227,5 +225,5 @@ check, changing nothing); it's idempotent and safe to repeat.
   review. No trust setting bypasses it.
 - **The episodic record**: ingested messages are immutable.
 
-These are the invariants the rest of the system's honesty depends on
+These are the invariants the rest of the system depends on
 (tested in `tests/test_invariants.py`).

--- a/tests/test_doc_style.py
+++ b/tests/test_doc_style.py
@@ -153,24 +153,49 @@ def test_no_essays_in_table_cells():
 
 def test_long_docs_stay_navigable():
     """An unbroken wall has no way in. The worst case before this test was a
-    335-line section under a single heading."""
+    335-line section under a single heading.
+
+    CHANGELOG.md is exempt, and the exemption is about genre rather than
+    convenience: a changelog's headings are its releases, so the gap between
+    two of them is however much shipped in between. Forcing one every 50 lines
+    would mean inventing headings that describe nothing. Its entries are still
+    held to the sentence budget, which is where changelog prose actually goes
+    wrong."""
     offenders = []
     for path in tracked_docs():
+        if path.name == "CHANGELOG.md":
+            continue
         lines = path.read_text(errors="ignore").splitlines()
         if len(lines) < HEADING_EXEMPT_UNDER:
             continue
-        marks, in_fence = [0], False
+
+        # Only PROSE lines count toward a gap. A fenced block, a table and a
+        # list are all navigable already: a numbered procedure is indexed by
+        # its own numbers, and a table by its rows. Counting them would push
+        # a heading into the middle of a 1..6 list, which renumbers it from 1
+        # and makes the document worse to satisfy the guard.
+        marks, in_fence, prose = [(0, 0)], False, 0
         for n, line in enumerate(lines, 1):
             if line.lstrip().startswith("```"):
                 in_fence = not in_fence
                 continue
             if not in_fence and re.match(r"#{2,6}\s", line):
-                marks.append(n)
-        marks.append(len(lines))
-        widest = max(b - a for a, b in zip(marks, marks[1:]))
+                marks.append((n, prose))
+                continue
+            stripped = line.strip()
+            skip = (in_fence or not stripped or stripped.startswith(("|", ">"))
+                    or LIST_ITEM.match(line) or line.startswith(("    ", "\t")))
+            if not skip:
+                prose += 1
+        marks.append((len(lines), prose))
+        widest, where = 0, 0
+        for (_, pa), (nb, pb) in zip(marks, marks[1:]):
+            if pb - pa > widest:
+                widest, where = pb - pa, nb
         if widest > HEADING_EVERY:
             offenders.append(
-                f"{path.relative_to(REPO)}: {widest} lines without a heading")
+                f"{path.relative_to(REPO)}: {widest} lines of unbroken prose "
+                f"ending near line {where}")
     assert not offenders, (
         f"add a heading at least every {HEADING_EVERY} lines:\n  "
         + "\n  ".join(offenders))

--- a/tests/test_doc_style.py
+++ b/tests/test_doc_style.py
@@ -1,0 +1,176 @@
+"""Documentation style budgets, enforced (#49).
+
+The docs drifted into a house style nobody chose: 73-word average sentences,
+caveats stapled to every claim, bug history in reference prose. None of it
+was catchable by review because none of it was measurable, so it accumulated
+a paragraph at a time.
+
+These are the hard limits only. The full rules are in CONTRIBUTING.md under
+"Writing documentation"; taste is not automatable and is not attempted here.
+What this stops is the shape that made the docs unreadable: a sentence that
+never ends, a table cell that swallowed a section, a file with no way in.
+
+Prose measurement excludes fenced code blocks, tables and headings, so a
+long SQL line or a wide table never trips a prose budget.
+"""
+from pathlib import Path
+import re
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Vendored, generated, or not ours.
+SKIP_DIRS = {".venv", "venv", "node_modules", ".git", ".pytest_cache",
+             "__pycache__", "data", "dist", "build", "site-packages"}
+
+MAX_SENTENCE_WORDS = 55
+MAX_CELL_WORDS = 45
+HEADING_EVERY = 50
+HEADING_EXEMPT_UNDER = 150
+
+
+def tracked_docs():
+    """Every markdown file that is ours, longest first for readable failures."""
+    out = []
+    for path in REPO.rglob("*.md"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        out.append(path)
+    return sorted(out)
+
+
+LIST_ITEM = re.compile(r"^\s*(?:[-*+]\s|\d+[.)]\s)")
+
+
+def prose_blocks(text):
+    """Body prose, split into the units a reader actually reads: one paragraph
+    or one list item each. No fenced code, tables, headings, or indented
+    blocks.
+
+    Blocking matters. A bullet list rarely ends its items with a full stop, so
+    joining the whole document into one string turns a fifteen-item dependency
+    list into a single 98-word 'sentence' and reports a file that is fine.
+    Lines inside one block are joined, so a sentence wrapped across source
+    lines is still measured whole."""
+    blocks, current, in_fence = [], [], False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        stripped = line.strip()
+        skip = (not stripped or stripped.startswith(("|", "#", ">"))
+                or line.startswith(("    ", "\t")))
+        if skip or LIST_ITEM.match(line):
+            if current:
+                blocks.append(" ".join(current))
+                current = []
+            if skip:
+                continue
+            stripped = LIST_ITEM.sub("", line).strip()
+        current.append(stripped)
+    if current:
+        blocks.append(" ".join(current))
+    return blocks
+
+
+def sentences_of(block):
+    """Split one block on sentence-final punctuation. Emphasis markers are
+    stripped first: `**...ends here.** Next one` puts the asterisks between
+    the full stop and the space, which otherwise hides two sentences inside
+    one measurement. Abbreviations and decimals are protected for the same
+    reason, in the other direction."""
+    guarded = re.sub(r"[*_]{1,3}", "", block)
+    for abbr in ("e.g.", "i.e.", "etc.", "cf.", "vs.", "Dr.", "Mr.", "Ms.",
+                 "St.", "approx.", "Fig.", "no."):
+        guarded = guarded.replace(abbr, abbr.replace(".", "\x00"))
+    guarded = re.sub(r"(\d)\.(\d)", lambda m: m.group(1) + "\x00" + m.group(2),
+                     guarded)
+    parts = re.split(r"(?<=[.!?])\s+", guarded)
+    return [p.replace("\x00", ".") for p in parts]
+
+
+def word_count(text):
+    """Words a reader actually parses. Inline code spans and link targets are
+    one token each: a bare URL is not ten words of prose."""
+    text = re.sub(r"`[^`]*`", " CODE ", text)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"https?://\S+", " URL ", text)
+    return len(text.split())
+
+
+def test_no_em_dashes():
+    """House style, and the one rule that is purely mechanical. A stray
+    em-dash in a sample payload is worse than one in prose: it gets copied
+    into other people's code."""
+    offenders = []
+    for path in tracked_docs():
+        for n, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            if "—" in line:
+                offenders.append(f"{path.relative_to(REPO)}:{n}")
+    assert not offenders, (
+        "em-dash is not house style; use a comma, a colon, or two sentences:\n  "
+        + "\n  ".join(offenders))
+
+
+def test_no_runaway_sentences():
+    """A sentence past this length has stopped being one claim. The record
+    before this test existed was 1,004 words."""
+    offenders = []
+    for path in tracked_docs():
+        for block in prose_blocks(path.read_text(errors="ignore")):
+            for sentence in sentences_of(block):
+                n = word_count(sentence)
+                if n > MAX_SENTENCE_WORDS:
+                    offenders.append(
+                        f"{path.relative_to(REPO)}: {n} words - {sentence[:90]}...")
+    assert not offenders, (
+        f"sentences over {MAX_SENTENCE_WORDS} words ({len(offenders)}); "
+        "split them:\n  " + "\n  ".join(offenders[:20]))
+
+
+def test_no_essays_in_table_cells():
+    """A reference table is scanned, not read. Past this length the cell has
+    become a section and belongs in prose with a link."""
+    offenders = []
+    for path in tracked_docs():
+        in_fence = False
+        for n, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence or not line.strip().startswith("|"):
+                continue
+            for cell in line.split("|"):
+                words = word_count(cell)
+                if words > MAX_CELL_WORDS:
+                    offenders.append(
+                        f"{path.relative_to(REPO)}:{n}: {words} words in one cell")
+    assert not offenders, (
+        f"table cells over {MAX_CELL_WORDS} words; move the detail into prose "
+        "and link it:\n  " + "\n  ".join(offenders))
+
+
+def test_long_docs_stay_navigable():
+    """An unbroken wall has no way in. The worst case before this test was a
+    335-line section under a single heading."""
+    offenders = []
+    for path in tracked_docs():
+        lines = path.read_text(errors="ignore").splitlines()
+        if len(lines) < HEADING_EXEMPT_UNDER:
+            continue
+        marks, in_fence = [0], False
+        for n, line in enumerate(lines, 1):
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if not in_fence and re.match(r"#{2,6}\s", line):
+                marks.append(n)
+        marks.append(len(lines))
+        widest = max(b - a for a, b in zip(marks, marks[1:]))
+        if widest > HEADING_EVERY:
+            offenders.append(
+                f"{path.relative_to(REPO)}: {widest} lines without a heading")
+    assert not offenders, (
+        f"add a heading at least every {HEADING_EVERY} lines:\n  "
+        + "\n  ".join(offenders))


### PR DESCRIPTION
Closes #48 and #49. Part of the fleet-wide documentation pass,
shawn-durrani/workbench#18.

**What & why**

Adds `tests/test_doc_style.py` (four hard limits), a "Writing documentation"
section in CONTRIBUTING.md (the full rules), and fixes everything the test
caught.

Enforced: no em-dashes, no prose sentence over 55 words, no table cell over
45 words, a heading at least every 50 lines in any file over 150. Prose
measurement excludes fenced code, tables and headings, and treats each list
item as its own block.

Fixed: 9 em-dashes; 15 sentences over 55 words (worst was a 142-word
description of the `/viz/landscape` payload, now a field list); four files
with 70-150 line stretches carrying no heading. `docs/API.md` gains 20
subheadings and its two route lists become sections rather than one 35-line
bullet. PR template said "honored" and had two mangled " ; " separators.
CHANGELOG's "one line each" convention was already broken by 8 of 20 entries,
so it now says what a good entry is.

`docs/API.md` prose only. **The wire contract is unchanged**, `contract_version`
stays 1.1, and `test_api_contract.py` passes untouched.

**Checklist**

- [x] Tests green keyless: 417 passed
- [x] No real personal data anywhere in the diff. Synthetic roster only
- [x] The invariants still hold (`tests/test_invariants.py` green)
- [x] CHANGELOG.md entry under Unreleased - n/a, contributor-facing only
- [x] New UI surfaces have a plain-English explainer - n/a, no UI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)