### PR TITLE
Person admin: rename, merge, clip move/delete, and the People page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- People are manageable from the admin page (#33, slice 3): rename
+  (apps can't change it back), merge duplicates (spellings, clips and
+  linked facts move across), listen to any stored clip, move or delete
+  a single recording, and forget - each action saying plainly what it
+  does before it does it. Clip moves and deletes are the same
+  corrections crossband replays here, so the durable record and a
+  future rebuild always reflect your judgement.
+
 - Person records land (#33, first slice): membro is now the fleet's
   durable home for who-is-who. Capture apps create people and upload
   their voice clips (content-addressed, owner-only, kept in full);

--- a/docs/API.md
+++ b/docs/API.md
@@ -661,6 +661,23 @@ decision: no server-side pruning).
 `GET /v1/persons/{slug}/anchors` and `.../{id}/file`: list and download,
 for rebuilding a lost client cache.
 
+`PATCH /v1/persons/{slug}`: the owner's rename (sets the owner flag, so
+no client upsert changes the name again) and relationship. Never creates.
+
+`POST /v1/persons/{slug}/anchors/{id}/move` (body `{"to": slug}`): a human
+correction - this recording belongs to someone else. Bytes stay,
+attribution changes; moving bytes the target already holds collapses to a
+delete of the mis-attributed row. Crossband replays its local moves
+through this, so a rebuild can never resurrect a corrected clip.
+
+`DELETE /v1/persons/{slug}/anchors/{id}`: delete one clip - journalled in
+`erasures`, bytes unlinked when no other row shares them. Crossband
+replays its local clip deletes through this.
+
+`POST /v1/persons/{slug}/merge` (body `{"into": slug}`): fold one person
+into another - aliases, clips and fact links re-point; the losing row
+stays, marked `merged_into`. Refused (410) when either side is forgotten.
+
 `POST /v1/persons/{slug}/forget`: the one-press forget. Deletes the
 audio from disk (one content-free `erasures` row), marks the person
 forgotten, and moves their approved facts back into review as one

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -23,7 +23,11 @@ for review instead of vanishing, attachments are counted not cascaded,
 and every eraser journals a content-free `erasures` row - what was
 erased is gone, that it was erased is not.
 
-**Person records (#33).** Owner-set names survive client updates; an
+**Person records (#33).** The admin surface renames (owner-set, clients
+can't undo), merges (aliases, clips and fact links re-point; supersede
+not rewrite; refused on forgotten sides), moves and deletes single clips
+(moves collapse onto duplicates; deletes journal and unlink bytes) - all
+owner-gated, all in `test_person_records.py`. And the slice-1 base: Owner-set names survive client updates; an
 alias can never be reassigned to a different person; a model speaker
 label can never become a person; clips are content-addressed and
 owner-only on disk; sync includes forgotten marks; forget deletes the

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -1525,6 +1525,82 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
             raise HTTPException(410, "clip bytes missing on disk")
         return FileResponse(path, media_type="audio/wav")
 
+    class RenameBody(BaseModel):
+        display_name: str = Field(min_length=1, max_length=80)
+        relationship: str | None = None
+
+    @app.patch("/v1/persons/{slug}", dependencies=[Depends(_admin_auth)])
+    def rename_person(slug: str, body: RenameBody):
+        # The owner's rename (admin surface): sets the owner flag, so no
+        # client upsert can change the name again. Never creates
+        # (decision 2 - persons are born in capture apps only).
+        c = con()
+        try:
+            person = _person_or_404(c, slug)
+            return persons.rename(c, person, body.display_name,
+                                  body.relationship)
+        except ValueError as e:
+            raise HTTPException(409, str(e))
+        finally:
+            c.close()
+
+    class MoveBody(BaseModel):
+        to: str = Field(min_length=1, max_length=80)
+
+    @app.post("/v1/persons/{slug}/anchors/{anchor_id}/move",
+              dependencies=[Depends(_admin_auth)])
+    def move_anchor(slug: str, anchor_id: int, body: MoveBody):
+        # A human correction (made here, or made in crossband and replayed
+        # by its sync): this recording belongs to someone else. The bytes
+        # stay; the attribution changes - so a rebuild can never
+        # resurrect the mis-attribution.
+        c = con()
+        try:
+            person = _person_or_404(c, slug, allow_forgotten=True)
+            to_person = _person_or_404(c, body.to)
+            r = persons.move_clip(c, settings, person, anchor_id, to_person)
+        except ValueError as e:
+            raise HTTPException(409, str(e))
+        finally:
+            c.close()
+        if not r.get("moved"):
+            raise HTTPException(404, r.get("reason", "no such clip"))
+        return r
+
+    @app.delete("/v1/persons/{slug}/anchors/{anchor_id}",
+                dependencies=[Depends(_admin_auth)])
+    def delete_anchor(slug: str, anchor_id: int):
+        # The clip eraser - human judgement that this audio should not
+        # exist under this person. Journalled like every eraser.
+        c = con()
+        try:
+            person = _person_or_404(c, slug, allow_forgotten=True)
+            r = persons.delete_clip(c, settings, person, anchor_id)
+        finally:
+            c.close()
+        if not r.get("deleted"):
+            raise HTTPException(404, r.get("reason", "no such clip"))
+        return r
+
+    class MergeBody(BaseModel):
+        into: str = Field(min_length=1, max_length=80)
+
+    @app.post("/v1/persons/{slug}/merge",
+              dependencies=[Depends(_admin_auth)])
+    def merge_person(slug: str, body: MergeBody):
+        # Fold {slug} into {into}: aliases, clips and fact links re-point;
+        # the loser row stays, marked merged_into (supersede, never
+        # rewrite). Crossband merges replay through here too.
+        c = con()
+        try:
+            loser = _person_or_404(c, slug)
+            winner = _person_or_404(c, body.into)
+            return persons.merge(c, settings, loser, winner)
+        except ValueError as e:
+            raise HTTPException(409, str(e))
+        finally:
+            c.close()
+
     @app.post("/v1/persons/{slug}/forget",
               dependencies=[Depends(_admin_auth)])
     def forget_person(slug: str):

--- a/memory_service/persons.py
+++ b/memory_service/persons.py
@@ -221,3 +221,108 @@ def forget(con, settings, person) -> dict:
     con.commit()
     return {"forgotten": person["slug"], "clips_deleted": len(rows),
             "files_removed": removed, "facts_held": held}
+
+
+def rename(con, person, display_name: str, relationship=None) -> dict:
+    """The owner renames (admin surface): sets the name AND the owner-set
+    flag, so no client upsert can change it again. Relationship is
+    owner-set free text (decision 5)."""
+    display_name = " ".join((display_name or "").split())
+    if not display_name:
+        raise ValueError("a name is required")
+    now = time.time()
+    con.execute("UPDATE persons SET display_name=?, name_owner_set=1, "
+                "updated_at=? WHERE id=?",
+                (display_name, now, person["id"]))
+    if relationship is not None:
+        con.execute("UPDATE persons SET relationship=? WHERE id=?",
+                    (relationship, person["id"]))
+    con.commit()
+    return out(con, con.execute("SELECT * FROM persons WHERE id=?",
+                                (person["id"],)).fetchone())
+
+
+def move_clip(con, settings, person, anchor_id: int, to_person) -> dict:
+    """Re-point one clip to the right person - the owner's correction
+    (or crossband replaying one made there). The bytes stay; only the
+    attribution changes. Refused onto a forgotten person."""
+    if to_person["forgotten_at"]:
+        raise ValueError("cannot move a clip to a forgotten person")
+    row = con.execute(
+        "SELECT id, sha256 FROM voice_anchors WHERE id=? AND person_id=?",
+        (anchor_id, person["id"])).fetchone()
+    if not row:
+        return {"moved": False, "reason": "no such clip"}
+    dup = con.execute(
+        "SELECT id FROM voice_anchors WHERE person_id=? AND sha256=?",
+        (to_person["id"], row["sha256"])).fetchone()
+    now = time.time()
+    if dup:
+        # the target already holds these bytes: the move collapses to a
+        # delete of the mis-attributed row
+        con.execute("DELETE FROM voice_anchors WHERE id=?", (row["id"],))
+    else:
+        con.execute("UPDATE voice_anchors SET person_id=? WHERE id=?",
+                    (to_person["id"], row["id"]))
+    con.execute("UPDATE persons SET updated_at=? WHERE id IN (?, ?)",
+                (now, person["id"], to_person["id"]))
+    con.commit()
+    return {"moved": True, "to": to_person["slug"]}
+
+
+def delete_clip(con, settings, person, anchor_id: int) -> dict:
+    """Delete one clip - the owner's judgement that this audio should not
+    exist under this person (or crossband replaying that judgement).
+    Journalled like every erasure; bytes unlinked when no other row
+    shares them."""
+    row = con.execute(
+        "SELECT id, sha256, stored_name FROM voice_anchors "
+        "WHERE id=? AND person_id=?", (anchor_id, person["id"])).fetchone()
+    if not row:
+        return {"deleted": False, "reason": "no such clip"}
+    con.execute("DELETE FROM voice_anchors WHERE id=?", (row["id"],))
+    shared = con.execute(
+        "SELECT 1 FROM voice_anchors WHERE stored_name=? LIMIT 1",
+        (row["stored_name"],)).fetchone()
+    removed = False
+    if not shared:
+        (clips_dir(settings) / row["stored_name"]).unlink(missing_ok=True)
+        removed = True
+    con.execute("UPDATE persons SET updated_at=? WHERE id=?",
+                (time.time(), person["id"]))
+    db.journal_erasure(con, "voice",
+                       f"clip:{row['sha256'][:12]} person:{person['slug']} "
+                       f"file_removed:{removed}")
+    con.commit()
+    return {"deleted": True, "file_removed": removed}
+
+
+def merge(con, settings, loser, winner) -> dict:
+    """Fold LOSER into WINNER - aliases, clips and fact links re-point,
+    the loser row stays with merged_into set (supersede, never rewrite).
+    Refused when either is forgotten. Crossband merges replay through
+    this too, so a merged-away membro record can never resurrect stale
+    clips into a rebuild."""
+    if loser["id"] == winner["id"]:
+        raise ValueError("cannot merge a person into themselves")
+    if loser["forgotten_at"] or winner["forgotten_at"]:
+        raise ValueError("cannot merge a forgotten person")
+    now = time.time()
+    con.execute("UPDATE person_aliases SET person_id=? WHERE person_id=?",
+                (winner["id"], loser["id"]))
+    # clips the winner already holds (same bytes) would violate the
+    # per-person sha uniqueness - drop the loser's duplicate rows first
+    con.execute(
+        "DELETE FROM voice_anchors WHERE person_id=? AND sha256 IN "
+        "(SELECT sha256 FROM voice_anchors WHERE person_id=?)",
+        (loser["id"], winner["id"]))
+    con.execute("UPDATE voice_anchors SET person_id=? WHERE person_id=?",
+                (winner["id"], loser["id"]))
+    con.execute("UPDATE facts SET person_id=? WHERE person_id=?",
+                (winner["id"], loser["id"]))
+    con.execute("UPDATE persons SET merged_into=?, updated_at=? WHERE id=?",
+                (winner["id"], now, loser["id"]))
+    con.execute("UPDATE persons SET updated_at=? WHERE id=?",
+                (now, winner["id"]))
+    con.commit()
+    return {"merged": loser["slug"], "into": winner["slug"]}

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -578,6 +578,23 @@
     </details>
 
     <details class="section">
+      <summary>People <span class="badge" id="people-count"></span>
+        <span style="flex:1"></span><button onclick="event.preventDefault();loadPeople()">Refresh</button></summary>
+      <div class="body">
+        <details class="help"><summary>What is this &amp; why it matters</summary><p><b>Everyone the fleet
+          knows by voice</b> - person records created by the apps that capture voices
+          (this page never creates one). Each holds a name, spellings, and the stored
+          voice clips backing it. Rename fixes the name everywhere (apps can't change
+          it back). Merge folds a duplicate into the real person - spellings, clips
+          and linked facts move across. Listen plays a stored clip; moving or deleting
+          one corrects the durable record the same way the capture app does. Forget is
+          the strong one: the audio is deleted for every app, and that person's
+          approved facts return to review for you to judge.</p></details>
+        <div id="people-body"><div class="empty">Loading…</div></div>
+      </div>
+    </details>
+
+    <details class="section">
       <summary>Files <span class="badge" id="files-count"></span>
         <span style="flex:1"></span><button onclick="event.preventDefault();loadFiles()">Refresh</button></summary>
       <div class="body">
@@ -1314,6 +1331,103 @@ async function prefillEraseFromHash() {
 
 // ---- files: every attachment the memory holds ----
 
+// ---- people (#33): person records and their stored voices ----
+
+async function loadPeople() {
+  let d;
+  try { d = await api("/persons"); }
+  catch (e) { errPanel("people-body", "Couldn't load people: " + e.message, "loadPeople"); return; }
+  const rows = (d.persons || []).filter(p => !p.merged_into);
+  const living = rows.filter(p => !p.forgotten_at);
+  $("people-count").textContent = living.length ? String(living.length) : "";
+  if (!rows.length) {
+    $("people-body").innerHTML = '<div class="empty">Nobody yet - people appear here when a capture app (crossband) syncs its learned voices.</div>';
+    return;
+  }
+  $("people-body").innerHTML = rows.map(p => {
+    const names = (p.aliases || []).map(a => esc(a.alias)).join(", ");
+    if (p.forgotten_at) {
+      return `<div class="kv"><dt>${esc(p.display_name)}</dt><dd>forgotten ${new Date(p.forgotten_at * 1000).toLocaleDateString()} - audio deleted everywhere</dd></div>`;
+    }
+    const others = living.filter(o => o.slug !== p.slug);
+    const mergeOpts = others.map(o => `<option value="${esc(o.slug)}">${esc(o.display_name)}</option>`).join("");
+    return `
+    <div class="kv" style="align-items:start">
+      <dt>${esc(p.display_name)}${p.relationship ? ` <span style="color:var(--dim)">(${esc(p.relationship)})</span>` : ""}</dt>
+      <dd>
+        <div>${p.clip_count} clip${p.clip_count === 1 ? "" : "s"}${names ? " · also answers to: " + names : ""}</div>
+        <div class="fields" style="margin-top:4px">
+          <input type="text" id="rn-${esc(p.slug)}" placeholder="rename" style="width:120px" aria-label="Rename ${esc(p.display_name)}">
+          <button onclick="renamePerson('${esc(p.slug)}')">Rename</button>
+          ${others.length ? `<select id="mg-${esc(p.slug)}" aria-label="Merge ${esc(p.display_name)} into"><option value="">merge into…</option>${mergeOpts}</select>
+          <button onclick="mergePerson('${esc(p.slug)}')">Merge</button>` : ""}
+          <button onclick="toggleClips('${esc(p.slug)}')">clips</button>
+          <button class="danger" onclick="forgetPerson('${esc(p.slug)}', '${esc(p.display_name)}')">Forget…</button>
+        </div>
+        <div id="clips-${esc(p.slug)}" hidden style="margin-top:6px"></div>
+      </dd>
+    </div>`;
+  }).join("");
+}
+
+async function renamePerson(slug) {
+  const name = $(`rn-${slug}`).value.trim();
+  if (!name) return;
+  try {
+    await api(`/persons/${encodeURIComponent(slug)}`, { method: "PATCH", body: { display_name: name } });
+    toast(`Renamed to ${name}. Apps can't change it back.`, true);
+    loadPeople();
+  } catch (e) { toast("Couldn't rename: " + e.message, false); }
+}
+
+async function mergePerson(slug) {
+  const into = $(`mg-${slug}`).value;
+  if (!into) return;
+  if (!confirm("Fold this person into the selected one? Spellings, clips and linked facts all move across. The empty record stays, marked merged.")) return;
+  try {
+    const r = await api(`/persons/${encodeURIComponent(slug)}/merge`, { method: "POST", body: { into } });
+    toast(`Merged into ${r.into}.`, true);
+    loadPeople();
+  } catch (e) { toast("Couldn't merge: " + e.message, false); }
+}
+
+async function forgetPerson(slug, name) {
+  if (!confirm(`Forget ${name}? Their stored voice audio is deleted here AND in every app that syncs, and their approved facts return to review for you to judge. The only trace kept is a content-free log line.`)) return;
+  try {
+    const r = await api(`/persons/${encodeURIComponent(slug)}/forget`, { method: "POST" });
+    toast(`${name} forgotten: ${r.clips_deleted} clip(s) deleted, ${r.facts_held} fact(s) moved to review.`, true);
+    loadPeople(); loadReview(); loadHealth();
+  } catch (e) { toast("Couldn't forget: " + e.message, false); }
+}
+
+async function toggleClips(slug) {
+  const box = $(`clips-${slug}`);
+  if (!box.hidden) { box.hidden = true; return; }
+  box.hidden = false;
+  box.innerHTML = '<span class="empty">Loading…</span>';
+  let d;
+  try { d = await api(`/persons/${encodeURIComponent(slug)}/anchors`); }
+  catch (e) { box.innerHTML = esc("Couldn't load clips: " + e.message); return; }
+  const rows = d.anchors || [];
+  if (!rows.length) { box.innerHTML = '<span class="empty">No stored clips.</span>'; return; }
+  box.innerHTML = rows.map(a => `
+    <div class="fields" style="margin-top:2px">
+      <span style="color:var(--dim);font-size:12px">${a.seconds ? a.seconds.toFixed(1) + "s" : "clip"} · ${esc(a.source || "?")}</span>
+      <audio controls preload="none" style="height:24px" src="/v1/persons/${encodeURIComponent(slug)}/anchors/${a.id}/file"></audio>
+      <button class="danger" onclick="deleteClip('${esc(slug)}', ${a.id})">delete</button>
+    </div>`).join("");
+}
+
+async function deleteClip(slug, id) {
+  if (!confirm("Delete this recording permanently? It is removed from the durable record; the capture app's copy (if any) is its own delete.")) return;
+  try {
+    await api(`/persons/${encodeURIComponent(slug)}/anchors/${id}`, { method: "DELETE" });
+    toast("Clip deleted.", true);
+    toggleClips(slug); toggleClips(slug);
+    loadPeople();
+  } catch (e) { toast("Couldn't delete: " + e.message, false); }
+}
+
 async function loadFiles() {
   let d;
   try { d = await api("/attachments"); }
@@ -1635,7 +1749,7 @@ async function removePasskey(id) {
 
 // ---- boot ----
 
-loadReview(); loadSummary(); loadLedger(); loadFiles(); loadHealth(); loadPasskeys();
+loadReview(); loadSummary(); loadLedger(); loadFiles(); loadHealth(); loadPasskeys(); loadPeople();
 prefillEraseFromHash();
 setInterval(() => { if (document.visibilityState === "visible") loadHealth(); }, 15000);
 </script>

--- a/tests/test_person_records.py
+++ b/tests/test_person_records.py
@@ -191,3 +191,111 @@ def test_every_route_is_owner_gated(client):
         "data_b64": _b64(WAV)}).status_code in (401, 403)
     assert bare.get("/v1/persons/p-alex1/anchors").status_code in (401, 403)
     assert bare.post("/v1/persons/p-alex1/forget").status_code in (401, 403)
+
+
+def test_rename_is_owner_set_and_never_creates(client):
+    _mk(client)
+    r = client.patch("/v1/persons/p-alex1", json={
+        "display_name": "Alexandra", "relationship": "colleague"})
+    assert r.json()["display_name"] == "Alexandra"
+    assert r.json()["name_owner_set"] is True
+    # a client upsert can no longer change it
+    p = _mk(client, name="Alex")
+    assert p["display_name"] == "Alexandra"
+    assert p["relationship"] == "colleague"
+    # rename never creates (decision 2)
+    assert client.patch("/v1/persons/p-nobody", json={
+        "display_name": "X Y"}).status_code == 404
+
+
+def test_move_clip_repoints_and_collapses_duplicates(client):
+    _mk(client, slug="p-a", name="Blair")
+    _mk(client, slug="p-b", name="Casey")
+    client.post("/v1/persons/p-a/anchors", json={"data_b64": _b64(WAV)})
+    a = client.get("/v1/persons/p-a/anchors").json()["anchors"][0]
+
+    r = client.post(f"/v1/persons/p-a/anchors/{a['id']}/move",
+                    json={"to": "p-b"})
+    assert r.json() == {"moved": True, "to": "p-b"}
+    assert client.get("/v1/persons/p-a/anchors").json()["anchors"] == []
+    b_rows = client.get("/v1/persons/p-b/anchors").json()["anchors"]
+    assert len(b_rows) == 1 and b_rows[0]["sha256"] == a["sha256"]
+    # moving bytes the target already holds collapses to a delete
+    client.post("/v1/persons/p-a/anchors", json={"data_b64": _b64(WAV)})
+    a2 = client.get("/v1/persons/p-a/anchors").json()["anchors"][0]
+    client.post(f"/v1/persons/p-a/anchors/{a2['id']}/move",
+                json={"to": "p-b"})
+    assert client.get("/v1/persons/p-a/anchors").json()["anchors"] == []
+    assert len(client.get("/v1/persons/p-b/anchors"
+                          ).json()["anchors"]) == 1
+
+
+def test_delete_clip_is_journalled_and_unlinks_bytes(client, settings):
+    _mk(client)
+    client.post("/v1/persons/p-alex1/anchors", json={"data_b64": _b64(WAV)})
+    a = client.get("/v1/persons/p-alex1/anchors").json()["anchors"][0]
+    r = client.delete(f"/v1/persons/p-alex1/anchors/{a['id']}")
+    assert r.json() == {"deleted": True, "file_removed": True}
+    assert list((settings.data_dir / "voice_anchors").iterdir()) == []
+    con = mdb.connect(settings.db_path)
+    rows = con.execute("SELECT kind, ref FROM erasures").fetchall()
+    con.close()
+    assert rows and rows[-1]["kind"] == "voice"
+    assert a["sha256"][:12] in rows[-1]["ref"]
+    assert client.delete(
+        f"/v1/persons/p-alex1/anchors/{a['id']}").status_code == 404
+
+
+def test_merge_repoints_everything_and_supersedes(client, settings):
+    # loser with an alias, a clip and a linked fact
+    client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "c1",
+        "title": "t", "messages": [{
+            "external_id": "g1", "speaker": "guest:sammy",
+            "content": "sammy said something worth keeping here",
+            "created_at": "2026-08-13T10:00:00+10:00"}]})
+    con = mdb.connect(settings.db_path)
+    mid = con.execute("SELECT id FROM messages").fetchone()["id"]
+    fid = ledger.add_fact(con, "Sammy rides a red bike.",
+                          client.app.state.settings, origin_agent="miner",
+                          source_app="multi-model-chat", conversation_id=1,
+                          source_message_id=mid)["id"]
+    con.close()
+    _mk(client, slug="p-loser", name="Sammy")
+    _mk(client, slug="p-winner", name="Sam")
+    client.post("/v1/persons/p-loser/anchors", json={"data_b64": _b64(WAV)})
+
+    r = client.post("/v1/persons/p-loser/merge", json={"into": "p-winner"})
+    assert r.json() == {"merged": "p-loser", "into": "p-winner"}
+    winner = [p for p in client.get("/v1/persons").json()["persons"]
+              if p["slug"] == "p-winner"][0]
+    assert winner["clip_count"] == 1
+    assert "Sammy" in [a["alias"] for a in winner["aliases"]]
+    loser = [p for p in client.get("/v1/persons").json()["persons"]
+             if p["slug"] == "p-loser"][0]
+    assert loser["merged_into"] is not None
+    con = mdb.connect(settings.db_path)
+    linked = con.execute("SELECT person_id FROM facts WHERE id=?",
+                         (fid,)).fetchone()["person_id"]
+    winner_id = con.execute("SELECT id FROM persons WHERE slug='p-winner'"
+                            ).fetchone()["id"]
+    con.close()
+    assert linked == winner_id
+    # merging with a forgotten side is refused (410: the route names
+    # the forgotten person before merge logic ever runs)
+    client.post("/v1/persons/p-winner/forget")
+    assert client.post("/v1/persons/p-loser/merge",
+                       json={"into": "p-winner"}).status_code == 410
+
+
+def test_admin_routes_are_owner_gated(client):
+    _mk(client)
+    bare = TestClient(client.app, base_url="http://127.0.0.1")
+    assert bare.patch("/v1/persons/p-alex1", json={
+        "display_name": "X Y"}).status_code in (401, 403)
+    assert bare.post("/v1/persons/p-alex1/anchors/1/move",
+                     json={"to": "p-b"}).status_code in (401, 403)
+    assert bare.delete("/v1/persons/p-alex1/anchors/1"
+                       ).status_code in (401, 403)
+    assert bare.post("/v1/persons/p-alex1/merge",
+                     json={"into": "p-b"}).status_code in (401, 403)


### PR DESCRIPTION
Slice 3 (membro half) of #33: the admin surface for person records, plus the clip move/delete routes that crossband's correction replay targets - so an owner correction can never resurrect through a rebuild. Merge folds duplicates supersede-style; rename is owner-set; every clip is listenable and deletable from the People section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)