### PR TITLE
The wire knows who spoke: speaker_identity on ingest (contract 1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ House convention: user-visible change, one line each, newest first.
 
 ## Unreleased
 
+- The wire knows who spoke (#33, final slice; contract 1.2). A message
+  arriving on ingest may carry the sending app's structured belief -
+  which person record, how confident, and how it knows. Facts mined
+  from such a message link to the person automatically when the
+  identity is human-confirmed (introduced, owner-corrected) or a
+  strong voice match; weaker guesses never auto-link. Old clients are
+  untouched: without the field everything behaves exactly as 1.1.
+
 - People are manageable from the admin page (#33, slice 3): rename
   (apps can't change it back), merge duplicates (spellings, clips and
   linked facts move across), listen to any stored clip, move or delete

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# Memory Service API: the HTTP contract, v1.1
+# Memory Service API: the HTTP contract, v1.2
 
 The contract between Membro and its clients. Owned by this repo.
 Versioned; breaking changes bump the major version. Clients check `contract_version`
@@ -8,6 +8,13 @@ repo's CI (against the real service) and in each client's CI (against the stub).
 - Base URL: `http://127.0.0.1:8901/v1`
 - Local-only: the server refuses to bind a non-loopback address unless
   `MEMORY_AUTH_TOKEN` is set (then: `Authorization: Bearer <token>`).
+- **1.2 (#33): messages on `/ingest` may carry `speaker_identity`** -
+  which person record the sending app believes spoke (`person` slug,
+  `confidence` 0..1, `method`: introduced | voice-match | by-elimination
+  | owner-correction). Stored verbatim beside the message. A fact born
+  from an identified message links to that person when the identity is
+  strong (introduced/owner-correction always; voice-match at 0.8+; weaker
+  never auto-binds). Absent field = exactly the 1.1 behaviour.
 - **1.1: some endpoints require the owner credential ALWAYS, even on
   loopback.** This is a *separate, stricter* check from the loopback-vs-token
   rule above. Sixteen routes carry that always-on check, and these are
@@ -57,7 +64,7 @@ repo's CI (against the real service) and in each client's CI (against the stub).
 ```json
 {
   "status": "ok|degraded",
-  "contract_version": "1.1",
+  "contract_version": "1.2",
   "db": {"facts": 0, "messages": 0, "size_bytes": 0, "integrity": "ok",
           "fts_in_sync": true, "last_backup_at": null},
   "capabilities": {"embeddings": true, "miner_model": "claude-haiku-4-5"},

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -23,7 +23,12 @@ for review instead of vanishing, attachments are counted not cascaded,
 and every eraser journals a content-free `erasures` row - what was
 erased is gone, that it was erased is not.
 
-**Person records (#33).** The admin surface renames (owner-set, clients
+**Person records (#33).** The wire identity (contract 1.2,
+`test_identity_wire.py`): `speaker_identity` stores verbatim and absent
+means 1.1 behaviour exactly; facts bind per the owner's policy
+(introduced/owner-correction always, voice-match at 0.8+, weaker never);
+merged slugs resolve to their winner, forgotten slugs bind nothing, and
+binding never changes whether a fact is held. Admin surface and base: The admin surface renames (owner-set, clients
 can't undo), merges (aliases, clips and fact links re-point; supersede
 not rewrite; refused on forgotten sides), moves and deletes single clips
 (moves collapse onto duplicates; deletes journal and unlink bytes) - all

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -81,11 +81,22 @@ class IngestAttachment(BaseModel):
     data_b64: str = Field(..., max_length=34_000_000)
 
 
+class SpeakerIdentity(BaseModel):
+    """#33, contract 1.2: which person record the sending app believes
+    spoke, and how it knows. The label string stays authoritative
+    provenance; this is the structured belief beside it."""
+    person: str | None = None            # membro person slug
+    confidence: float = Field(0.0, ge=0.0, le=1.0)
+    method: str = ""    # introduced | voice-match | by-elimination | owner-correction
+
+
 class IngestMessage(BaseModel):
     external_id: str
     speaker: str
     content: str
     created_at: str  # ISO 8601
+    # additive, contract 1.2 (#33): absent = exactly the 1.1 behaviour
+    speaker_identity: SpeakerIdentity | None = None
     # additive, contract 1.0 (2026-07-11); per-message count capped so one
     # request can't balloon past what the per-file bound intended (security
     # pass 2026-07-11 — the trust boundary is local, the memory isn't infinite)
@@ -1035,6 +1046,8 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         try:
             msgs = [{"external_id": m.external_id, "speaker": m.speaker,
                      "content": m.content, "created_at": _ts(m.created_at),
+                     "speaker_identity": (m.speaker_identity.model_dump()
+                                          if m.speaker_identity else None),
                      "attachments": [a.model_dump() for a in m.attachments]}
                     for m in body.messages]
             res = episodic.ingest(c, body.source_app, body.conversation_id,

--- a/memory_service/config.py
+++ b/memory_service/config.py
@@ -53,7 +53,7 @@ class Settings(BaseModel):
     trusted_apps: list[str] = []  # register your own client app slugs; empty = no app-trusted writes
     grounding_allowlist: list[str] = []    # user-specific ubiquitous nouns, config not code
 
-    contract_version: str = "1.1"
+    contract_version: str = "1.2"  # 1.2 (#33): speaker_identity on ingest
 
     @property
     def db_path(self) -> Path:

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS messages(
   speaker TEXT NOT NULL,
   content TEXT NOT NULL,
   created_at REAL NOT NULL,
+  speaker_identity TEXT NOT NULL DEFAULT '',  -- #33 contract 1.2: {person, confidence, method} json, or ''
   UNIQUE(conversation_id, external_id)
 );
 
@@ -228,6 +229,10 @@ def init(settings) -> None:
         cols = {r[1] for r in con.execute("PRAGMA table_info(facts)")}
         if "person_id" not in cols:
             con.execute("ALTER TABLE facts ADD COLUMN person_id INTEGER")
+        mcols = {r[1] for r in con.execute("PRAGMA table_info(messages)")}
+        if "speaker_identity" not in mcols:
+            con.execute("ALTER TABLE messages ADD COLUMN speaker_identity "
+                        "TEXT NOT NULL DEFAULT ''")
         con.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         con.commit()
         # Cheap (row-count comparison) and safe (no-op unless desynced) — see

--- a/memory_service/episodic.py
+++ b/memory_service/episodic.py
@@ -11,6 +11,7 @@ local, uncapped memory is to never lose this stuff.
 """
 
 import base64
+import json
 import hashlib
 import io
 import logging
@@ -104,10 +105,12 @@ def ingest(con, source_app: str, conversation_external_id: str,
             (source_app, conversation_external_id, title, db.now())).lastrowid
     ingested = skipped = attached = 0
     for m in messages:
+        identity = m.get("speaker_identity")
         cur = con.execute(
             "INSERT OR IGNORE INTO messages(conversation_id, external_id, speaker, "
-            "content, created_at) VALUES(?,?,?,?,?)",
-            (conv_id, m["external_id"], m["speaker"], m["content"], m["created_at"]))
+            "content, created_at, speaker_identity) VALUES(?,?,?,?,?,?)",
+            (conv_id, m["external_id"], m["speaker"], m["content"], m["created_at"],
+             json.dumps(identity) if identity else ""))
         if cur.rowcount:
             ingested += 1
         else:

--- a/memory_service/ledger.py
+++ b/memory_service/ledger.py
@@ -5,6 +5,7 @@ are all reversible state changes; hard delete exists only as the human-initiated
 API endpoint.
 """
 
+import json
 import logging
 import re
 import threading
@@ -119,14 +120,30 @@ def add_fact(con, content: str, settings, *, source: str = "user",
             return {"id": dup["id"], "quarantined": bool(dup["quarantined_at"]),
                     "duplicate": True}
     ts = db.now()
+    # #33 contract 1.2: a fact born from a message that carries a
+    # structured speaker identity links to that person when the identity
+    # is strong enough (persons.binding - human-confirmed always,
+    # voice-match at 0.8+, weaker never). Same hold rules either way:
+    # the link changes what review can say, never whether a fact is held.
+    person_id = None
+    if source_message_id is not None:
+        row = con.execute("SELECT speaker_identity FROM messages WHERE id=?",
+                          (source_message_id,)).fetchone()
+        if row and row["speaker_identity"]:
+            from . import persons as persons_mod
+            try:
+                person_id = persons_mod.binding(
+                    con, json.loads(row["speaker_identity"]))
+            except (ValueError, KeyError):
+                person_id = None
     cur = con.execute(
         "INSERT INTO facts(content, source, origin_agent, conversation_id, "
         "source_message_id, created_at, event_date, confidence, importance, "
-        "content_hash, quarantined_at, quarantine_reason) "
-        "VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+        "content_hash, quarantined_at, quarantine_reason, person_id) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (content, source, origin, conversation_id, source_message_id, ts,
          event_date or ts, confidence, importance, db.content_hash(content),
-         ts if reason else None, reason))
+         ts if reason else None, reason, person_id))
     con.commit()
     _spawn_embed(settings, cur.lastrowid, content)
     return {"id": cur.lastrowid, "quarantined": bool(reason)}

--- a/memory_service/persons.py
+++ b/memory_service/persons.py
@@ -35,8 +35,34 @@ from . import db, walls
 
 DIR_NAME = "voice_anchors"
 
-# Sources a human stood behind - mirrors crossband's vouch sources (#83).
-HUMAN_METHODS = ("introduction", "owner-correction")
+# Methods a human stood behind - mirrors crossband's vouch sources (#83).
+HUMAN_METHODS = ("introduced", "owner-correction")
+VOICE_MATCH_MIN_CONFIDENCE = 0.8   # owner decision 3 (membro#33)
+
+
+def binding(con, identity) -> int | None:
+    """The person a fact should link to, per owner decision 3: a
+    human-confirmed identity (introduced / owner-correction) always binds;
+    a voice-match binds at confidence 0.8 or above; by-elimination and
+    anything unknown never auto-binds - those stay for the review queue's
+    human. A merged-away slug resolves to its winner; a forgotten or
+    unknown slug binds nothing."""
+    if not identity or not identity.get("person"):
+        return None
+    method = identity.get("method") or ""
+    if method not in HUMAN_METHODS and not (
+            method == "voice-match"
+            and (identity.get("confidence") or 0) >= VOICE_MATCH_MIN_CONFIDENCE):
+        return None
+    person = _row(con, identity["person"])
+    for _ in range(8):                     # follow merges, bounded
+        if person is None or person["forgotten_at"]:
+            return None
+        if not person["merged_into"]:
+            return person["id"]
+        person = con.execute("SELECT * FROM persons WHERE id=?",
+                             (person["merged_into"],)).fetchone()
+    return None
 
 
 def clips_dir(settings):

--- a/tests/test_identity_wire.py
+++ b/tests/test_identity_wire.py
@@ -1,0 +1,132 @@
+"""The wire identity field (#33 slice 4, contract 1.2).
+
+A message on /ingest may now say which person record the sending app
+believes spoke, and how it knows. The contract under test:
+
+- the field is stored verbatim beside the message; absent = exactly the
+  1.1 behaviour;
+- facts born from an identified message link to the person per owner
+  decision 3: introduced and owner-correction always bind, voice-match
+  binds at confidence 0.8 or above, by-elimination and unknown methods
+  never auto-bind;
+- a merged-away slug resolves to its winner; forgotten or unknown slugs
+  bind nothing;
+- the link never changes whether a fact is held - only what review can
+  say about it;
+- the health handshake announces contract 1.2.
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import api as api_mod
+from memory_service import db as mdb
+from memory_service import ledger
+
+
+@pytest.fixture
+def client(settings, fake_llm):
+    app = api_mod.create_app(settings)
+    c = TestClient(app, base_url="http://127.0.0.1",
+                   headers={"Authorization": f"Bearer {app.state.admin_token}"})
+    c.app = app
+    return c
+
+
+def _person(client, slug="p-sam", name="Sam"):
+    r = client.post("/v1/persons", json={
+        "slug": slug, "display_name": name,
+        "origin_client": "multi-model-chat"})
+    assert r.status_code == 200
+    return r.json()
+
+
+def _ingest_with_identity(client, identity, ref="g1"):
+    body = {"external_id": ref, "speaker": "guest:sam",
+            "content": f"a guest turn worth remembering {ref}",
+            "created_at": "2026-08-14T10:00:00+10:00"}
+    if identity is not None:
+        body["speaker_identity"] = identity
+    r = client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "c1",
+        "title": "t", "messages": [body]})
+    assert r.json()["ingested"] == 1
+
+
+def _fact_from(client, settings, ref):
+    con = mdb.connect(settings.db_path)
+    try:
+        mid = con.execute("SELECT id FROM messages WHERE external_id=?",
+                          (ref,)).fetchone()["id"]
+        fid = ledger.add_fact(con, f"Sam said a thing in {ref} today.",
+                              client.app.state.settings,
+                              origin_agent="miner",
+                              source_app="multi-model-chat",
+                              conversation_id=1,
+                              source_message_id=mid)["id"]
+        return con.execute("SELECT person_id, quarantined_at FROM facts "
+                           "WHERE id=?", (fid,)).fetchone()
+    finally:
+        con.close()
+
+
+def test_identity_is_stored_and_absent_means_1_1(client, settings):
+    _ingest_with_identity(client, {"person": "p-sam", "confidence": 0.9,
+                                   "method": "voice-match"}, ref="g1")
+    _ingest_with_identity(client, None, ref="g2")
+    con = mdb.connect(settings.db_path)
+    rows = {r["external_id"]: r["speaker_identity"] for r in con.execute(
+        "SELECT external_id, speaker_identity FROM messages")}
+    con.close()
+    assert json.loads(rows["g1"])["method"] == "voice-match"
+    assert rows["g2"] == ""
+
+
+def test_binding_follows_decision_three(client, settings):
+    _person(client)
+    cases = [
+        ({"person": "p-sam", "method": "introduced"}, True),
+        ({"person": "p-sam", "method": "owner-correction"}, True),
+        ({"person": "p-sam", "method": "voice-match",
+          "confidence": 0.8}, True),
+        ({"person": "p-sam", "method": "voice-match",
+          "confidence": 0.79}, False),
+        ({"person": "p-sam", "method": "by-elimination",
+          "confidence": 0.99}, False),
+        ({"person": "p-sam", "method": "something-new"}, False),
+        ({"person": "p-nobody", "method": "introduced"}, False),
+        ({"person": None, "method": "introduced"}, False),
+    ]
+    for i, (identity, should_bind) in enumerate(cases):
+        ref = f"g{i}"
+        _ingest_with_identity(client, identity, ref=ref)
+        row = _fact_from(client, settings, ref)
+        assert (row["person_id"] is not None) == should_bind, identity
+        # binding never changes holding: trusted-app miner facts stay live
+        assert row["quarantined_at"] is None
+
+
+def test_a_merged_slug_binds_to_the_winner_and_forgotten_binds_nothing(
+        client, settings):
+    _person(client, slug="p-loser", name="Sammy")
+    _person(client, slug="p-winner", name="Sam")
+    client.post("/v1/persons/p-loser/merge", json={"into": "p-winner"})
+    _ingest_with_identity(client, {"person": "p-loser",
+                                   "method": "introduced"}, ref="g1")
+    row = _fact_from(client, settings, "g1")
+    con = mdb.connect(settings.db_path)
+    winner_id = con.execute("SELECT id FROM persons WHERE slug='p-winner'"
+                            ).fetchone()["id"]
+    con.close()
+    assert row["person_id"] == winner_id
+
+    client.post("/v1/persons/p-winner/forget")
+    _ingest_with_identity(client, {"person": "p-winner",
+                                   "method": "introduced"}, ref="g2")
+    assert _fact_from(client, settings, "g2")["person_id"] is None
+
+
+def test_health_announces_contract_1_2(client):
+    assert client.get("/v1/health").json()["contract_version"] == "1.2"


### PR DESCRIPTION
Final slice of #33: the additive speaker_identity field on ingest, stored verbatim, binding facts to person records per the owner's decision 3 (human-confirmed always, voice-match at 0.8+, weaker never). Contract bumps to 1.2; absent field = 1.1 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)