### PR TITLE
Web-derived facts are held for review: web_sources stamp, contract 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- A fact learnt from a web page is held for review (#55, contract 1.3).
+  Messages on ingest and explicit saves may carry `web_sources`, the
+  domains a web tool read in the round that produced them. A fact born
+  from a stamped turn, or saved with a stamp, quarantines with a
+  `web-derived:` reason naming the domains, and the review queue groups
+  these holds under "Learnt from a web page" with the usual per-group
+  bulk actions. Older clients that never send the field keep exactly
+  the 1.2 behaviour.
+
 - The wire knows who spoke (#33, final slice; contract 1.2). A message
   arriving on ingest may carry the sending app's structured belief -
   which person record, how confident, and how it knows. Facts mined

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# Memory Service API: the HTTP contract, v1.2
+# Memory Service API: the HTTP contract, v1.3
 
 The contract between Membro and its clients. Owned by this repo.
 Versioned; breaking changes bump the major version. Clients check `contract_version`
@@ -10,6 +10,13 @@ repo's CI (against the real service) and in each client's CI (against the stub).
 - Base URL: `http://127.0.0.1:8901/v1`
 - Local-only: the server refuses to bind a non-loopback address unless
   `MEMORY_AUTH_TOKEN` is set (then: `Authorization: Bearer <token>`).
+- **1.3 (#55): messages on `/ingest` and saves on `POST /facts` may carry
+  `web_sources`**: the web domains a tool read in the round that produced
+  the message or save (a list of strings, max 20). Stored verbatim beside
+  the message. A fact born from a stamped message, or saved with a stamp,
+  is quarantined with a `web-derived:` reason naming the domains. A public
+  page must not write memory by phrasing a sentence well. The origin trust
+  gate outranks the stamp. Absent field = exactly the 1.2 behaviour.
 - **1.2 (#33): messages on `/ingest` may carry `speaker_identity`**:
   which person record the sending app believes spoke (`person` slug,
   `confidence` 0..1, `method`: introduced | voice-match | by-elimination
@@ -77,7 +84,7 @@ at the end of it.
 ```json
 {
   "status": "ok|degraded",
-  "contract_version": "1.2",
+  "contract_version": "1.3",
   "db": {"facts": 0, "messages": 0, "size_bytes": 0, "integrity": "ok",
           "fts_in_sync": true, "last_backup_at": null},
   "capabilities": {"embeddings": true, "miner_model": "claude-haiku-4-5"},

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -97,6 +97,11 @@ class IngestMessage(BaseModel):
     created_at: str  # ISO 8601
     # additive, contract 1.2 (#33): absent = exactly the 1.1 behaviour
     speaker_identity: SpeakerIdentity | None = None
+    # additive, contract 1.3 (#55): domains a web tool touched in the round
+    # that produced this message. A fact born from a stamped message is held
+    # for review - a public page must not write memory by phrasing a
+    # sentence well. Absent = exactly the 1.2 behaviour.
+    web_sources: list[str] = Field([], max_length=20)
     # additive, contract 1.0 (2026-07-11); per-message count capped so one
     # request can't balloon past what the per-file bound intended (security
     # pass 2026-07-11 — the trust boundary is local, the memory isn't infinite)
@@ -127,6 +132,10 @@ class FactBody(BaseModel):
     confidence: str = "high"
     origin_agent: str = "user"
     source_app: str | None = None
+    # additive, contract 1.3 (#55): non-empty = this save happened in a round
+    # that read the web, so the fact is held (the miner cannot be bypassed by
+    # an explicit save).
+    web_sources: list[str] = Field([], max_length=20)
 
 
 class FactPatch(BaseModel):
@@ -1048,6 +1057,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
                      "content": m.content, "created_at": _ts(m.created_at),
                      "speaker_identity": (m.speaker_identity.model_dump()
                                           if m.speaker_identity else None),
+                     "web_sources": list(m.web_sources),
                      "attachments": [a.model_dump() for a in m.attachments]}
                     for m in body.messages]
             res = episodic.ingest(c, body.source_app, body.conversation_id,
@@ -1095,7 +1105,8 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
                 c, body.content, settings, source="model" if
                 body.origin_agent != "user" else "user",
                 origin_agent=body.origin_agent, source_app=body.source_app,
-                event_date=_ts(body.event_date), confidence=body.confidence)
+                event_date=_ts(body.event_date), confidence=body.confidence,
+                web_sources=body.web_sources)
         except ValueError as e:
             raise HTTPException(422, str(e))
         finally:

--- a/memory_service/config.py
+++ b/memory_service/config.py
@@ -53,7 +53,7 @@ class Settings(BaseModel):
     trusted_apps: list[str] = []  # register your own client app slugs; empty = no app-trusted writes
     grounding_allowlist: list[str] = []    # user-specific ubiquitous nouns, config not code
 
-    contract_version: str = "1.2"  # 1.2 (#33): speaker_identity on ingest
+    contract_version: str = "1.3"  # 1.3 (#55): web_sources on ingest + facts; 1.2 (#33): speaker_identity on ingest
 
     @property
     def db_path(self) -> Path:

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS messages(
   content TEXT NOT NULL,
   created_at REAL NOT NULL,
   speaker_identity TEXT NOT NULL DEFAULT '',  -- #33 contract 1.2: {person, confidence, method} json, or ''
+  web_sources TEXT NOT NULL DEFAULT '',       -- #55 contract 1.3: json list of web domains the turn drew on, or ''
   UNIQUE(conversation_id, external_id)
 );
 
@@ -232,6 +233,9 @@ def init(settings) -> None:
         mcols = {r[1] for r in con.execute("PRAGMA table_info(messages)")}
         if "speaker_identity" not in mcols:
             con.execute("ALTER TABLE messages ADD COLUMN speaker_identity "
+                        "TEXT NOT NULL DEFAULT ''")
+        if "web_sources" not in mcols:  # #55 additive, same pattern
+            con.execute("ALTER TABLE messages ADD COLUMN web_sources "
                         "TEXT NOT NULL DEFAULT ''")
         con.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         con.commit()

--- a/memory_service/episodic.py
+++ b/memory_service/episodic.py
@@ -106,11 +106,13 @@ def ingest(con, source_app: str, conversation_external_id: str,
     ingested = skipped = attached = 0
     for m in messages:
         identity = m.get("speaker_identity")
+        webs = m.get("web_sources") or []
         cur = con.execute(
             "INSERT OR IGNORE INTO messages(conversation_id, external_id, speaker, "
-            "content, created_at, speaker_identity) VALUES(?,?,?,?,?,?)",
+            "content, created_at, speaker_identity, web_sources) VALUES(?,?,?,?,?,?,?)",
             (conv_id, m["external_id"], m["speaker"], m["content"], m["created_at"],
-             json.dumps(identity) if identity else ""))
+             json.dumps(identity) if identity else "",
+             json.dumps(webs) if webs else ""))
         if cur.rowcount:
             ingested += 1
         else:

--- a/memory_service/ledger.py
+++ b/memory_service/ledger.py
@@ -84,9 +84,16 @@ def add_fact(con, content: str, settings, *, source: str = "user",
              importance: int | None = None, conversation_id: int | None = None,
              source_message_id: int | None = None,
              quarantine_reason: str | None = None,
+             web_sources: list[str] | None = None,
              dedupe_in_conversation: bool = False) -> dict:
     """Append one fact. Untrusted origins are quarantined at creation (the gate);
     a caller-supplied quarantine_reason (e.g. a wall flag) also quarantines.
+
+    `web_sources` (#55, contract 1.3): domains the authoring round read from
+    the web - passed explicitly by /v1/facts, and inherited automatically
+    from the source message's stamp on the mining path. Non-empty means the
+    fact is held with a `web-derived:` reason: a public page must not write
+    memory by phrasing a sentence well. The origin gate outranks it.
 
     `dedupe_in_conversation` is a NARROW write-time guard for the mining path
     (#36): when set, re-adding a fact whose normalized content already exists
@@ -126,9 +133,18 @@ def add_fact(con, content: str, settings, *, source: str = "user",
     # voice-match at 0.8+, weaker never). Same hold rules either way:
     # the link changes what review can say, never whether a fact is held.
     person_id = None
+    webs = [str(w).strip().lower() for w in (web_sources or []) if str(w).strip()]
     if source_message_id is not None:
-        row = con.execute("SELECT speaker_identity FROM messages WHERE id=?",
-                          (source_message_id,)).fetchone()
+        row = con.execute("SELECT speaker_identity, web_sources FROM messages "
+                          "WHERE id=?", (source_message_id,)).fetchone()
+        if row and row["web_sources"]:
+            # #55: the mining path inherits the stamp from the turn itself,
+            # so the miner needs no knowledge of this rule.
+            try:
+                webs += [str(w).strip().lower()
+                         for w in json.loads(row["web_sources"]) if str(w).strip()]
+            except ValueError:
+                pass
         if row and row["speaker_identity"]:
             from . import persons as persons_mod
             try:
@@ -136,6 +152,10 @@ def add_fact(con, content: str, settings, *, source: str = "user",
                     con, json.loads(row["speaker_identity"]))
             except (ValueError, KeyError):
                 person_id = None
+    if reason is None and webs:
+        shown = ", ".join(sorted(set(webs))[:5])[:300]
+        reason = (f"web-derived: {shown} — a public page was read in this "
+                  "round; held for review before becoming canon")
     cur = con.execute(
         "INSERT INTO facts(content, source, origin_agent, conversation_id, "
         "source_message_id, created_at, event_date, confidence, importance, "

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -861,6 +861,7 @@ const REASON_CLASS_COPY = {
   "source-trust": "Untrusted source content",
   "importance": "Low importance",
   "external-write": "Written by external tooling",
+  "web-derived": "Learnt from a web page",
   "other": "Other holds",
 };
 

--- a/tests/test_identity_wire.py
+++ b/tests/test_identity_wire.py
@@ -128,5 +128,6 @@ def test_a_merged_slug_binds_to_the_winner_and_forgotten_binds_nothing(
     assert _fact_from(client, settings, "g2")["person_id"] is None
 
 
-def test_health_announces_contract_1_2(client):
-    assert client.get("/v1/health").json()["contract_version"] == "1.2"
+def test_health_announces_contract_1_3(client):
+    # 1.3 (#55) is additive over 1.2: web_sources on ingest and facts.
+    assert client.get("/v1/health").json()["contract_version"] == "1.3"

--- a/tests/test_web_derived_hold.py
+++ b/tests/test_web_derived_hold.py
@@ -1,0 +1,119 @@
+"""Web-derived hold (#55, contract 1.3): a fact born in a round that read the
+web is held for review, whichever door it arrives through. The stamp rides
+/v1/ingest per message and /v1/facts per save; the ledger applies the hold at
+one choke point, so the miner needs no knowledge of the rule."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import db as db_mod
+from memory_service import episodic, ledger
+from memory_service.api import create_app, reason_class
+
+
+@pytest.fixture
+def client(settings, fake_llm):
+    app = create_app(settings)
+    return TestClient(app, base_url="http://127.0.0.1",
+                      headers={"Authorization": f"Bearer {app.state.admin_token}"})
+
+
+def _ingest(client, messages):
+    r = client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "web1",
+        "title": "t", "messages": messages})
+    assert r.status_code == 200
+    return r
+
+
+def test_ingest_stores_the_stamp_and_absence_stays_1_2(client, settings):
+    _ingest(client, [
+        {"external_id": "m1", "speaker": "claude-x",
+         "content": "the summit is on the ninth of September",
+         "created_at": "2026-08-16T10:00:00+10:00",
+         "web_sources": ["news.example"]},
+        {"external_id": "m2", "speaker": "user",
+         "content": "noted, thanks",
+         "created_at": "2026-08-16T10:01:00+10:00"},
+    ])
+    c = db_mod.connect(settings.db_path)
+    try:
+        rows = {r["external_id"]: r["web_sources"] for r in
+                c.execute("SELECT external_id, web_sources FROM messages")}
+    finally:
+        c.close()
+    assert rows["m1"] == '["news.example"]'
+    assert rows["m2"] == ""  # absent field = exactly the 1.2 behaviour
+
+
+def test_fact_bound_to_a_stamped_message_is_held(client, settings):
+    _ingest(client, [
+        {"external_id": "m1", "speaker": "claude-x",
+         "content": "the vendor's new pricing starts next month",
+         "created_at": "2026-08-16T10:00:00+10:00",
+         "web_sources": ["vendor.example", "News.Example"]},
+    ])
+    c = db_mod.connect(settings.db_path)
+    try:
+        msg = c.execute("SELECT id, conversation_id FROM messages").fetchone()
+        # The mining path's call shape: trusted app, bound source message.
+        res = ledger.add_fact(
+            c, "the vendor's pricing changes next month", settings,
+            source="model", origin_agent="claude-x",
+            source_app="multi-model-chat",
+            conversation_id=msg["conversation_id"], source_message_id=msg["id"])
+        fact = c.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                         (res["id"],)).fetchone()
+    finally:
+        c.close()
+    assert res["quarantined"] is True
+    reason = fact["quarantine_reason"]
+    assert reason.startswith("web-derived: ")
+    assert "news.example" in reason and "vendor.example" in reason  # lowered
+    assert reason_class(reason) == "web-derived"
+
+
+def test_unstamped_message_keeps_the_trusted_baseline(settings, con):
+    episodic.ingest(con, "multi-model-chat", "conv2", [
+        {"external_id": "m1", "speaker": "claude-x", "content": "plain turn",
+         "created_at": 1755300000.0}])
+    msg = con.execute("SELECT id, conversation_id FROM messages").fetchone()
+    res = ledger.add_fact(
+        con, "a perfectly ordinary remembered fact", settings,
+        source="model", origin_agent="claude-x", source_app="multi-model-chat",
+        conversation_id=msg["conversation_id"], source_message_id=msg["id"])
+    assert res["quarantined"] is False
+
+
+def test_explicit_save_with_stamp_is_held(client, settings):
+    r = client.post("/v1/facts", json={
+        "content": "the library's new API launches at version nine",
+        "origin_agent": "claude-x", "source_app": "multi-model-chat",
+        "web_sources": ["docs.example"]})
+    assert r.status_code == 200
+    assert r.json()["quarantined"] is True
+    c = db_mod.connect(settings.db_path)
+    try:
+        reason = c.execute("SELECT quarantine_reason FROM facts").fetchone()[0]
+    finally:
+        c.close()
+    assert reason.startswith("web-derived: docs.example")
+
+
+def test_explicit_save_without_stamp_stays_trusted(client):
+    r = client.post("/v1/facts", json={
+        "content": "an unstamped save from the trusted app",
+        "origin_agent": "claude-x", "source_app": "multi-model-chat"})
+    assert r.status_code == 200
+    assert r.json()["quarantined"] is False
+
+
+def test_origin_gate_outranks_the_web_stamp(settings, con):
+    res = ledger.add_fact(
+        con, "a claim from an app nobody registered", settings,
+        source="model", origin_agent="stranger", source_app="unknown-app",
+        web_sources=["evil.example"])
+    assert res["quarantined"] is True
+    reason = con.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                         (res["id"],)).fetchone()[0]
+    assert reason.startswith("external write")  # the stronger gate names it


### PR DESCRIPTION
Fixes #55. The service half of crossband's web-viewing work (shawn-durrani/crossband#138): a fact learnt from a web page is held for review, whichever door it arrives through.

## What changes

- Contract 1.3, additive. `/v1/ingest` messages and `POST /v1/facts` saves may carry `web_sources`: the domains a web tool read in the round that produced them (list of strings, max 20). A client that never sends the field keeps exactly the 1.2 behaviour.
- The hold lives at one choke point, `ledger.add_fact`. It already reads the bound source message for speaker identity; it now reads the stamp from the same row. The mining path therefore inherits the rule with no miner changes, and an explicit save cannot bypass the miner: the API threads the save's own stamp through.
- A held fact's reason is `web-derived: <domains>`, so `reason_class` groups these under one review-queue heading ("Learnt from a web page") and #34's per-group bulk actions apply unchanged.
- The origin trust gate outranks the stamp: an untrusted writer stays an `external write` hold, web or not.
- Storage: `messages.web_sources` (JSON list or empty string), added with the same guarded-ALTER migration pattern as `speaker_identity`.

## Tests

`tests/test_web_derived_hold.py`: stamp stored on ingest and absent-field baseline, mining-shape hold with domains lowered and deduped in the reason, unstamped trusted baseline unchanged, explicit-save hold and its baseline, and gate-outranks-stamp. Contract pin updated (`test_health_announces_contract_1_3`). Full keyless suite: 432 passed.

## Follow-ups (noted, not in this PR)

- Crossband starts sending the stamp in crossband#138 slice 4.
- The fleet's contract smoke gains a 1.3 probe once both sides ship.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
