### PR TITLE
Grounding wall: alias-aware allowlist, sentence-initial capitals, spelling normalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- The grounding wall stops holding facts for three mechanical reasons
+  (#57). A word capitalised only because it starts a sentence is no
+  longer read as a name. "Wi-Fi" now grounds off "wifi" and short
+  hardware tokens ("M2", "GB", "ARM") ground on word boundaries. The
+  allowlist now includes every person name and alias membro already
+  holds, so a nickname in chat grounds the full name in a fact. An
+  entity genuinely absent from the source chat still holds.
+
 - A fact learnt from a web page is held for review (#55, contract 1.3).
   Messages on ingest and explicit saves may carry `web_sources`, the
   domains a web tool read in the round that produced them. A fact born

--- a/memory_service/mining.py
+++ b/memory_service/mining.py
@@ -15,7 +15,7 @@ import re
 import threading
 from datetime import datetime, timezone
 
-from . import captions, episodic, ledger, llm, recall, summary, walls
+from . import captions, episodic, ledger, llm, persons, recall, summary, walls
 
 # Per-conversation distill locks. A distill run reads the conversation's
 # `mined_upto` watermark once, then mines everything after it. Two runs for the
@@ -495,7 +495,9 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
     )
     out = llm.utility_complete(prompt, settings, max_tokens=1000)
     valid_ids = {f["id"] for f in recent}
-    allow = {w.lower() for w in settings.grounding_allowlist} | {settings.user_name.lower()}
+    allow = ({w.lower() for w in settings.grounding_allowlist}
+             | {settings.user_name.lower()}
+             | persons.grounding_names(con))  # #57: names membro already holds
     # #35: in a guest-present window an unbound fact cannot be attributed to
     # the owner, so before judging anything, give the miner ONE batched
     # corrective retry for every fact whose src= is missing or names no real

--- a/memory_service/persons.py
+++ b/memory_service/persons.py
@@ -95,6 +95,30 @@ def out(con, person) -> dict:
             "aliases": aliases, "clip_count": clips}
 
 
+def grounding_names(con) -> set[str]:
+    """Lowercased names, aliases, and their word tokens for every active
+    person — the personal half of the grounding allowlist (#57). The miner
+    may call a person by any name membro itself holds for them ("Alex"
+    spoken, "Alexandra" written), and the wall must not read that as an
+    invented entity. Personal nouns never live in code or committed config;
+    this reads them from the same table the People page manages."""
+    rows = con.execute(
+        "SELECT p.display_name AS n FROM persons p "
+        "WHERE p.merged_into IS NULL AND p.forgotten_at IS NULL "
+        "UNION "
+        "SELECT a.alias AS n FROM person_aliases a "
+        "JOIN persons p ON p.id = a.person_id "
+        "WHERE p.merged_into IS NULL AND p.forgotten_at IS NULL").fetchall()
+    names: set[str] = set()
+    for r in rows:
+        name = (r["n"] or "").strip().lower()
+        if not name:
+            continue
+        names.add(name)
+        names.update(t for t in name.split() if len(t) >= 2)
+    return names
+
+
 def model_label_collision(con, name: str, source_app: str = "") -> bool:
     """The participant boundary's server-side backstop (#65/#77): has this
     name ever been seen as a MODEL speaker label? A person may never be

--- a/memory_service/walls.py
+++ b/memory_service/walls.py
@@ -145,9 +145,21 @@ def drop_diagnostics() -> dict[str, int]:
         return dict(_DROP_COUNTS)
 
 
+# A capture position counts as a sentence start at the beginning of the
+# text or after terminal punctuation. Used by proper_nouns (#57): the miner
+# often opens a fact with a capitalised ordinary word ("Achieving...",
+# "Proposed fix..."), which is capitalisation-by-position, not a name.
+_SENT_START_RE = re.compile(r"(?:^|[.!?:;]\s+|\n\s*)[\"'(]*$")
+
+
+def _dehyphen(s: str) -> str:
+    return s.replace("-", "").replace("–", "")
+
+
 def proper_nouns(text: str, allowlist: set[str]) -> list[str]:
+    text = text or ""
     out = []
-    for m in _CAP_RE.finditer(text or ""):
+    for m in _CAP_RE.finditer(text):
         ph = m.group(0).strip().strip(".,;:!?'\"")
         low = ph.lower()
         if not ph or low in _STOPWORDS or low in allowlist:
@@ -155,20 +167,44 @@ def proper_nouns(text: str, allowlist: set[str]) -> list[str]:
         # multi-word capture made only of stopwords/allowed words ("The API")
         if all(t in _STOPWORDS or t in allowlist for t in low.split()):
             continue
+        # #57: a single word capitalised only because it starts a sentence is
+        # not an entity. It stays one when the same capitalised word recurs
+        # elsewhere in the fact (a real name used as an opener does).
+        if (" " not in ph and _SENT_START_RE.search(text[:m.start()])
+                and len(re.findall(rf"\b{re.escape(ph)}\b", text)) == 1):
+            continue
         out.append(ph)
     return out
+
+
+def _token_supported(low_tok: str, orig_tok: str, src: str) -> bool:
+    """One entity token supports grounding when found in the source. Tokens of
+    4+ characters keep the original loose substring match. Shorter tokens
+    qualify only when they look like hardware/acronym vocabulary (contain a
+    digit, or were written in capitals) and match on a word boundary (#57) —
+    'gb' must not ground off 'rugby'."""
+    if len(low_tok) >= 4:
+        return low_tok in src
+    if len(low_tok) >= 2 and (any(c.isdigit() for c in low_tok) or orig_tok.isupper()):
+        return re.search(rf"\b{re.escape(low_tok)}\b", src) is not None
+    return False
 
 
 def ungrounded_entities(fact: str, source_text: str, allowlist: set[str]) -> list[str]:
     """Proper nouns in `fact` with no support in `source_text`. Empty = grounded."""
     src = (source_text or "").lower()
+    src_dehyphened = _dehyphen(src)
     missing = []
     for ent in proper_nouns(fact, allowlist):
         low = ent.lower()
         if low in src:
             continue
-        toks = [t for t in re.split(r"[\s\-/.]+", low) if len(t) >= 4]
-        if toks and any(t in src for t in toks):
+        # #57: spelling normalisation — "Wi-Fi" grounds off "wifi" and the
+        # reverse, comparing hyphen-stripped forms of both sides.
+        if _dehyphen(low) in src_dehyphened:
+            continue
+        pairs = zip(re.split(r"[\s\-/.]+", low), re.split(r"[\s\-/.]+", ent))
+        if any(lt and _token_supported(lt, ot, src) for lt, ot in pairs):
             continue
         missing.append(ent)
     return missing

--- a/tests/test_walls.py
+++ b/tests/test_walls.py
@@ -173,3 +173,71 @@ def test_lexical_support_measures_wording_not_who_spoke():
     fact = "Alex's wife Sam dislikes coriander."
     assert walls.lexical_support(fact, "I hate coriander.", {"alex"}) == 1
     assert walls.lexical_support(fact, "Sam dislikes coriander.", {"alex"}) == 2
+
+
+# --- #57: the three mechanical false-positive shapes ---
+
+def test_sentence_initial_word_is_not_an_entity():
+    src = "the fan swap and drive choice make the unit quieter in practice"
+    fact = "Achieving the quiet-operation spec requires a fan swap."
+    assert walls.check(fact, src, set()) == []
+
+
+def test_sentence_initial_name_that_recurs_stays_an_entity():
+    fact = "Zorblatt shipped on Friday. The team praised Zorblatt."
+    assert "Zorblatt" in walls.proper_nouns(fact, set())
+
+
+def test_hyphen_spelling_grounds_both_ways():
+    assert walls.ungrounded_entities(
+        "The Wi-Fi setup", "the wifi kept dropping all week", set()) == []
+    assert walls.ungrounded_entities(
+        "The WiFi setup", "the wi-fi kept dropping all week", set()) == []
+
+
+def test_short_hardware_tokens_ground_on_word_boundary():
+    src = "the m2 max macbook has plenty of memory"
+    assert walls.ungrounded_entities(
+        "Alex's 64GB M2 Max Mac runs models locally", src, set()) == []
+
+
+def test_acronym_tokens_ground_but_never_by_substring():
+    assert walls.ungrounded_entities(
+        "The ARM NAS is slow", "an arm-based nas from 2012", set()) == []
+    # 'GB' must not ground off 'rugby'
+    assert walls.ungrounded_entities(
+        "GB Storage", "alex watched the rugby", set()) == ["GB Storage"]
+
+
+def test_genuinely_absent_entity_still_holds():
+    flags = walls.check("Alex added a PCIe GPU to the box.",
+                        "the box has room for expansion cards", set())
+    assert flags and "PCIe GPU" in flags[0]
+
+
+def test_grounding_names_covers_names_aliases_and_tokens(con, settings):
+    from memory_service import persons
+    persons.upsert(con, settings, slug="p-t1",
+                   display_name="Alexandra Quill", aliases=["Lexi"])
+    names = persons.grounding_names(con)
+    assert {"alexandra quill", "alexandra", "quill", "lexi"} <= names
+
+
+def test_person_alias_suppresses_grounding_hold(con, settings):
+    from memory_service import persons
+    persons.upsert(con, settings, slug="p-t2",
+                   display_name="Alexandra", aliases=["Lexi"])
+    fact = "The projector arrives with Alexandra."
+    src = "Lexi: I will bring the projector"
+    assert walls.check(fact, src, set()) != []          # held without names
+    allow = persons.grounding_names(con)
+    assert walls.check(fact, src, allow) == []          # cleared with them
+
+
+def test_forgotten_person_names_leave_the_allowlist(con, settings):
+    from memory_service import persons
+    persons.upsert(con, settings, slug="p-t3",
+                   display_name="Marisol", aliases=["Mari"])
+    con.execute("UPDATE persons SET forgotten_at=1 WHERE slug='p-t3'")
+    con.commit()
+    assert "marisol" not in persons.grounding_names(con)


### PR DESCRIPTION
Closes #57.

The three mechanical false-positive shapes from the issue, each with a synthetic test:

1. **Sentence-initial capitals**: a single word capitalised only because it opens a sentence is no longer treated as an entity. It stays one when the same capitalised word recurs in the fact.
2. **Spelling normalisation**: entity and source are also compared hyphen-stripped ("Wi-Fi" grounds off "wifi" and the reverse). The token rescue now accepts 2-3 character tokens when they contain a digit or were written in capitals ("M2", "GB", "ARM"), matching on a word boundary only, so "gb" can never ground off "rugby".
3. **Person aliases**: `persons.grounding_names(con)` feeds every active person's display name, aliases, and word tokens into the mining allowlist. Forgotten and merged people drop out. Personal nouns still never live in code or committed config.

No trust-model change: the wall still fails toward holding, and a genuinely absent entity ("PCIe GPU" never said) still quarantines.

Tests: 9 new in `tests/test_walls.py`; full suite 441 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)