### PR TITLE
Local OpenAI-compatible endpoint as a first-class utility-model choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- Local models are a first-class choice for the utility layer (#59).
+  A new `llm_base_url` setting points every non-claude model name at an
+  OpenAI-compatible server (Ollama, MLX, LM Studio); with it set, no API
+  key is required for that branch. Defaults are unchanged, cloud key
+  checks still fail loudly, and a dead local endpoint fails loudly too.
+
 - A fact learnt from a web page is held for review (#55, contract 1.3).
   Messages on ingest and explicit saves may carry `web_sources`, the
   domains a web tool read in the round that produced them. A fact born

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -82,12 +82,21 @@ proposes; granting permanence is always your action.
 | Setting | Default | What it does |
 |---|---|---|
 | `miner_model` | `claude-haiku-4-5` | Cheap model that extracts facts from chats |
+| `llm_base_url` | *(empty)* | OpenAI-compatible server for non-claude model names |
 | `trusted_apps` | `[]` | Apps whose saves skip quarantine; empty means none |
 | `grounding_allowlist` | `[]` | Proper nouns the walls should never question |
 
 **`miner_model`** runs often (after every chat), so it defaults cheap. If
 mined facts feel off, a stronger model here helps, at real cost, since it
 reads whole conversations.
+
+**`llm_base_url`** points every non-claude model name at an
+OpenAI-compatible server, such as Ollama's `http://127.0.0.1:11434/v1`.
+With it set, no API key is needed and nothing leaves your machine for
+mining, captions, or summaries. Pick a server that is always on; if it is
+down, mining fails loudly and retries later rather than losing anything.
+Each model setting routes on its own name, so a local miner can sit
+beside a cloud `summary_model`, or replace it too.
 
 **`trusted_apps`** is empty by default, so out of the box *nothing* is
 app-trusted: every write that isn't the literal `user` origin is quarantined

--- a/memory_service/config.py
+++ b/memory_service/config.py
@@ -42,6 +42,12 @@ class Settings(BaseModel):
     # round) and rebuilds are infrequent — a stronger model is worth it here
     # while the cheap miner keeps the high-volume extraction work.
     summary_model: str = "claude-sonnet-5"
+    # OpenAI-compatible endpoint for every non-claude model name (#59):
+    # Ollama, MLX, LM Studio, or OpenAI itself. Empty = the SDK default
+    # (api.openai.com). With a base URL set, no API key is required.
+    # Point it at an always-on server: mining depends on it, and a server
+    # tied to another app's lifecycle makes mining depend on that app.
+    llm_base_url: str = ""
     embedding_model: str = "text-embedding-3-small"
     memory_summary_words: int = 2000
     # (`summary_emergent_topics` lived here until 2026-07-26 (#13). Emergent

--- a/memory_service/llm.py
+++ b/memory_service/llm.py
@@ -1,6 +1,12 @@
 """Utility-model completions, lab-configurable — routed by model name.
 
-Fails loudly when the needed key is missing (no silent no-op mining runs)."""
+`claude*` models go to Anthropic; every other name goes to an
+OpenAI-compatible endpoint — OpenAI itself by default, or the server named
+by `llm_base_url` (#59): Ollama, MLX, LM Studio. With a base URL set no
+API key is required; local servers ignore the placeholder the SDK insists
+on. Fails loudly when a needed key is missing (no silent no-op mining
+runs); a dead local endpoint fails just as loudly, with a connection
+error at call time."""
 
 import os
 import threading
@@ -22,13 +28,36 @@ _lock = threading.Lock()
 _clients: dict = {}
 
 
-def _client(provider: str):
+def _base_url(settings) -> str:
+    return (getattr(settings, "llm_base_url", "") or "").strip()
+
+
+def _client(provider: str, settings=None):
     if provider not in _clients:
         with _lock:
             if provider not in _clients:
-                _clients[provider] = (anthropic.Anthropic() if provider == "anthropic"
-                                      else OpenAI())
+                if provider == "anthropic":
+                    _clients[provider] = anthropic.Anthropic()
+                else:
+                    kwargs = {}
+                    base = _base_url(settings)
+                    if base:
+                        kwargs["base_url"] = base
+                        if not os.environ.get("OPENAI_API_KEY"):
+                            # the SDK requires a key string; a local
+                            # server never reads it (#59)
+                            kwargs["api_key"] = "local"
+                    _clients[provider] = OpenAI(**kwargs)
     return _clients[provider]
+
+
+def _check_openai_key(model: str, settings) -> None:
+    if _base_url(settings):
+        return  # local/self-hosted endpoint: no key required (#59)
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise MissingKeyError(
+            f"utility model {model} needs OPENAI_API_KEY "
+            "(or llm_base_url for a local server)")
 
 
 def utility_complete(prompt: str, settings, max_tokens: int = 1000,
@@ -41,9 +70,8 @@ def utility_complete(prompt: str, settings, max_tokens: int = 1000,
             model=model, max_tokens=max_tokens,
             messages=[{"role": "user", "content": prompt}])
         return "".join(b.text for b in resp.content if b.type == "text").strip()
-    if not os.environ.get("OPENAI_API_KEY"):
-        raise MissingKeyError(f"utility model {model} needs OPENAI_API_KEY")
-    resp = _client("openai").chat.completions.create(
+    _check_openai_key(model, settings)
+    resp = _client("openai", settings).chat.completions.create(
         model=model, max_completion_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}])
     return (resp.choices[0].message.content or "").strip()
@@ -68,13 +96,12 @@ def utility_vision(prompt: str, images: list[tuple[str, str]], settings,
             model=model, max_tokens=max_tokens,
             messages=[{"role": "user", "content": content}])
         return "".join(b.text for b in resp.content if b.type == "text").strip()
-    if not os.environ.get("OPENAI_API_KEY"):
-        raise MissingKeyError(f"utility model {model} needs OPENAI_API_KEY")
+    _check_openai_key(model, settings)
     content = [{"type": "image_url",
                 "image_url": {"url": f"data:{mime};base64,{b64}"}}
                for mime, b64 in images]
     content.append({"type": "text", "text": prompt})
-    resp = _client("openai").chat.completions.create(
+    resp = _client("openai", settings).chat.completions.create(
         model=model, max_completion_tokens=max_tokens,
         messages=[{"role": "user", "content": content}])
     return (resp.choices[0].message.content or "").strip()

--- a/tests/test_llm_routing.py
+++ b/tests/test_llm_routing.py
@@ -1,0 +1,87 @@
+"""#59: routing and key rules for the utility-model layer."""
+
+import pytest
+
+from memory_service import llm
+from memory_service.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def fresh_clients(monkeypatch):
+    monkeypatch.setattr(llm, "_clients", {})
+
+
+def _settings(tmp_path, **kw):
+    return Settings(data_dir=tmp_path / "d", **kw)
+
+
+class _FakeOpenAI:
+    """Captures constructor kwargs and the last request; returns 'ok'."""
+    built: list = []
+    last_request: dict = {}
+
+    def __init__(self, **kwargs):
+        _FakeOpenAI.built.append(kwargs)
+
+        class _Completions:
+            @staticmethod
+            def create(**req):
+                _FakeOpenAI.last_request = req
+
+                class _Msg:
+                    content = "ok"
+
+                class _Choice:
+                    message = _Msg()
+
+                class _Resp:
+                    choices = [_Choice()]
+
+                return _Resp()
+
+        class _Chat:
+            completions = _Completions()
+
+        self.chat = _Chat()
+
+
+def test_claude_model_still_demands_anthropic_key(tmp_path, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    s = _settings(tmp_path, llm_base_url="http://127.0.0.1:11434/v1")
+    with pytest.raises(llm.MissingKeyError):
+        llm.utility_complete("hi", s, model="claude-haiku-4-5")
+
+
+def test_compat_model_without_base_url_demands_openai_key(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(llm.MissingKeyError):
+        llm.utility_complete("hi", _settings(tmp_path), model="qwen3")
+
+
+def test_base_url_needs_no_key_and_gets_placeholder(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(llm, "OpenAI", _FakeOpenAI)
+    _FakeOpenAI.built = []
+    s = _settings(tmp_path, llm_base_url="http://127.0.0.1:11434/v1")
+    assert llm.utility_complete("hi", s, model="qwen3") == "ok"
+    assert _FakeOpenAI.built == [
+        {"base_url": "http://127.0.0.1:11434/v1", "api_key": "local"}]
+
+
+def test_real_key_wins_over_placeholder(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(llm, "OpenAI", _FakeOpenAI)
+    _FakeOpenAI.built = []
+    s = _settings(tmp_path, llm_base_url="http://127.0.0.1:11434/v1")
+    llm.utility_complete("hi", s, model="qwen3")
+    assert _FakeOpenAI.built == [{"base_url": "http://127.0.0.1:11434/v1"}]
+
+
+def test_vision_on_compat_branch_builds_data_urls(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(llm, "OpenAI", _FakeOpenAI)
+    s = _settings(tmp_path, llm_base_url="http://127.0.0.1:11434/v1")
+    llm.utility_vision("describe", [("image/png", "QUJD")], s, model="llava")
+    content = _FakeOpenAI.last_request["messages"][0]["content"]
+    assert content[0]["image_url"]["url"] == "data:image/png;base64,QUJD"
+    assert content[-1] == {"type": "text", "text": "describe"}


### PR DESCRIPTION
Closes #59.

One new setting, `llm_base_url`, beside the model settings. Routing stays by model name:

- `claude*` models: Anthropic, loud `ANTHROPIC_API_KEY` check unchanged.
- Any other name, base URL unset: OpenAI, loud `OPENAI_API_KEY` check unchanged (message now mentions the alternative).
- Any other name, base URL set: no key demanded; a placeholder is passed when absent (the SDK requires one, local servers ignore it). A real `OPENAI_API_KEY` still wins when present.

A dead local endpoint fails loudly at call time with a connection error, same posture as `MissingKeyError`: no silent no-op mining runs. Captions already leave images pending with a logged warning on any caption failure, so a text-only local model degrades honestly with no change needed there. Each call site routes on its own model setting, so a local miner beside the cloud `summary_model` works with no extra code.

Docs: `llm_base_url` documented in TUNING.md beside `miner_model`, including the always-on guidance.

Tests: 5 new in `tests/test_llm_routing.py` (three key rules, placeholder vs real key, vision data URLs); full suite 437 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)