### PR TITLE
Search falls back when a valid FTS query returns no rows over a live record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- Transcript search survives an emptied search index (#38). An
+  empty-but-valid FTS index answers every query with zero rows without
+  raising, so drift read as a genuine no-match and the old fallback (it
+  only fired on exceptions) never ran. When a query comes back empty,
+  the query path now checks the index's shadow table: an empty index
+  over a non-empty record serves the bounded substring fallback and
+  logs the drift. Healthy no-match searches pay one O(1) probe and
+  return an honest empty result; the startup repair still rebuilds the
+  index itself.
+
 - Embeddings can run locally too, and model changes are space-safe
   (#60). `embedding_base_url` points memory search at any
   OpenAI-compatible server, no key required. The active embedding model

--- a/memory_service/episodic.py
+++ b/memory_service/episodic.py
@@ -147,10 +147,45 @@ def messages_after(con, conversation_id: int, after_id: int = 0) -> list[dict]:
         (conversation_id, after_id))]
 
 
+def _like_fallback(con, words, limit) -> list[dict]:
+    """The bounded non-FTS path: first word, substring match, newest first.
+    Serves FTS syntax edge cases and a drifted index alike."""
+    rows = con.execute(
+        "SELECT m.speaker, m.created_at, c.title, c.external_id conversation_id, "
+        "substr(m.content, 1, 200) AS content "
+        "FROM messages m JOIN conversations c ON c.id = m.conversation_id "
+        "WHERE m.content LIKE ? ORDER BY m.id DESC LIMIT ?",
+        (f"%{words[0]}%", limit))
+    return [dict(r) for r in rows]
+
+
+def _fts_index_drifted(con) -> bool:
+    """The detectable drift shape: messages_fts EMPTY while messages has
+    rows. An empty-but-valid index answers MATCH with zero rows without
+    raising, so it reads exactly like a genuine no-match. Probed via the
+    `_docsize` shadow table, same as db.fts_status — a read of the fts5
+    table itself reads THROUGH to the base table and would always look in
+    sync. Two O(1) existence probes, paid only when a query already came
+    back empty; an ordinary no-match on a healthy index costs the shadow
+    probe and stops. Partial drift (index non-empty but behind) is not
+    detectable per query; the startup repair (db.repair_fts via db.init)
+    owns that."""
+    try:
+        if con.execute("SELECT EXISTS(SELECT 1 FROM messages_fts_docsize)"
+                       ).fetchone()[0]:
+            return False
+    except Exception:
+        return False  # older/partial schema: nothing provable, no fallback
+    return bool(
+        con.execute("SELECT EXISTS(SELECT 1 FROM messages)").fetchone()[0])
+
+
 def search(con, query: str, limit: int = 20) -> list[dict]:
     """FTS5 over the whole record — messages AND attachment text; LIKE fallback
-    for FTS syntax edge cases. Attachment hits are labeled `file: <name>` in
-    the speaker slot so callers can render them without a schema change."""
+    for FTS syntax edge cases AND for a drifted-empty index, which answers
+    zero rows without raising and would otherwise read as a genuine
+    no-match. Attachment hits are labeled `file: <name>` in the speaker slot
+    so callers can render them without a schema change."""
     words = [w for w in (query or "").split() if w.strip()]
     if not words:
         return []
@@ -163,6 +198,12 @@ def search(con, query: str, limit: int = 20) -> list[dict]:
             "JOIN conversations c ON c.id = m.conversation_id "
             "WHERE messages_fts MATCH ? ORDER BY rank LIMIT ?", (match, limit))
         hits = [dict(r) for r in rows]
+        if not hits and _fts_index_drifted(con):
+            log.warning(
+                "messages_fts is empty while messages has rows — index "
+                "drift; serving the bounded LIKE fallback (the startup "
+                "repair rebuilds the index on next restart)")
+            return _like_fallback(con, words, limit)
         if len(hits) < limit:
             arows = con.execute(
                 "SELECT 'file: ' || a.filename AS speaker, a.created_at, c.title, "
@@ -175,10 +216,4 @@ def search(con, query: str, limit: int = 20) -> list[dict]:
             hits += [dict(r) for r in arows]
         return hits
     except Exception:
-        rows = con.execute(
-            "SELECT m.speaker, m.created_at, c.title, c.external_id conversation_id, "
-            "substr(m.content, 1, 200) AS content "
-            "FROM messages m JOIN conversations c ON c.id = m.conversation_id "
-            "WHERE m.content LIKE ? ORDER BY m.id DESC LIMIT ?",
-            (f"%{words[0]}%", limit))
-        return [dict(r) for r in rows]
+        return _like_fallback(con, words, limit)

--- a/tests/test_fts_repair.py
+++ b/tests/test_fts_repair.py
@@ -54,9 +54,11 @@ def test_repair_fts_fixes_deliberately_emptied_index(con, sample_conversation):
     assert status["messages_fts"]["fts_rows"] == 0
     assert status["messages_fts"]["in_sync"] is False
 
-    # This is the silent-failure symptom: no exception, just zero hits for
-    # content that is verifiably still in `messages`.
-    assert episodic.search(con, "Initech") == []
+    # The silent-failure symptom used to be zero hits with no exception.
+    # Since the query-path guard (#38), a drifted-EMPTY index falls back to
+    # the bounded LIKE path, so the content is still findable pre-repair.
+    drifted_hits = episodic.search(con, "Initech")
+    assert drifted_hits and any("Initech" in h["content"] for h in drifted_hits)
 
     result = db.repair_fts(con)
     assert result["repaired"] == ["messages_fts"]
@@ -139,3 +141,37 @@ def test_health_surfaces_fts_desync(settings):
     h = db.health(settings)
     assert h["fts_in_sync"] is False
     assert h["fts"]["messages_fts"]["in_sync"] is False
+
+
+def test_search_falls_back_when_the_index_is_empty_but_valid(
+        con, sample_conversation):
+    """#38: an empty-but-syntactically-valid index answers MATCH with zero
+    rows without raising, so the exception-only fallback never ran and drift
+    read as a genuine no-match. The query path now probes for exactly that
+    shape and serves the bounded LIKE fallback."""
+    con.execute("DROP TABLE messages_fts")
+    con.execute("CREATE VIRTUAL TABLE messages_fts USING fts5("
+                "content, content='messages', content_rowid='id')")
+    con.commit()
+    hits = episodic.search(con, "Initech")
+    assert hits and any("Initech" in h["content"] for h in hits)
+    # and a word genuinely absent from the record still finds nothing -
+    # the fallback is bounded, not a different answer
+    assert episodic.search(con, "Hooli") == []
+
+
+def test_healthy_no_match_never_falls_back(con, sample_conversation):
+    """An ordinary no-match on a HEALTHY index stays an honest empty result:
+    the drift probe sees a non-empty index and stops - no LIKE scan."""
+    assert db.fts_status(con)["messages_fts"]["in_sync"] is True
+    assert episodic.search(con, "Hooli") == []
+
+
+def test_empty_record_searches_empty(settings):
+    """A fresh, genuinely empty store: zero rows everywhere is not drift."""
+    db.init(settings)
+    con = db.connect(settings.db_path)
+    try:
+        assert episodic.search(con, "anything") == []
+    finally:
+        con.close()


### PR DESCRIPTION
Fixes #38, to its acceptance criteria.

`episodic.search` used its LIKE fallback only after an exception, and an empty-but-syntactically-valid FTS index answers MATCH with zero rows without raising - so silent index drift read as a genuine no-match and the fallback never ran, even with transcript rows present.

**When the fallback fires (the bounded rule):** only when the message query already came back empty AND the index's `_docsize` shadow table is empty while `messages` is not. The shadow-table probe matters: a read of the fts5 table itself reads through to the base table and always looks in sync - the exact trap `db.fts_status`'s own comment documents. Ordinary no-match searches on a healthy index pay one O(1) existence probe and return an honest empty result - no full scans. Partial drift (index behind but non-empty) is not detectable per query and stays owned by the startup repair (#37), as the issue intended: this protects the query path if drift recurs between health checks.

The fallback fires with a WARNING log naming the drift, so it leaves evidence rather than quietly papering over the index. FTS ranking and the healthy path are untouched. The old symptom pin in `test_fts_repair` (`search == []` on a drifted index) moves with the fix, as its own comment anticipated.

Suite: 467 passed, 0 failed, keyless on Python 3.12 (CI's version). Four new/changed tests: fallback on a populated base with an emptied index plus a genuinely-absent word staying empty, healthy no-match never falling back, an empty record not reading as drift, and the repair test asserting content stays findable pre-repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM)_