### PR TITLE
Docs: pre-publication issue numbers read as history labels, not links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,14 @@ what changed, and whoever comes next reconstructs the reasoning from
 the link. Branch from `main`, never off another open PR: squash-merging
 the first would orphan the second.
 
+One caveat when reading code comments: issue numbers in code that
+predates the 2026-08-06 public release refer to a private tracker that
+did not come with the repo. Read them as design-history labels, not
+links; the reasoning around them stands alone. They are rewritten
+opportunistically when a file is touched (#8), and a number can also
+name a real issue here by coincidence - `git blame` settles which
+tracker a comment meant.
+
 ## Rules
 
 - Tests accompany behaviour changes.


### PR DESCRIPTION
Part of #8 (not a close). A blame pass against the initial-release commit puts the true count at 219 comment lines citing the private pre-publication tracker - #8's ~60 undercounted by 3x - and some of those numbers now collide with real public issues, so a mass rewrite is a careful editorial job, not a sweep. Until each site is rewritten to stand alone, CONTRIBUTING's "How work lands" section now tells a reader what those numbers are, that the surrounding reasoning stands alone, and that `git blame` settles which tracker a given comment meant.

The census and the re-scope proposal are on #8. Doc-style and process-doc tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM)_