### PR TITLE
Code comments stand on their own instead of citing the private tracker

### DIFF
--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -7,20 +7,20 @@ which journals a content-free tombstone in `erasures` (#45).
 
 Exact-row endpoints (GET /facts, GET /review, and every verb that reads or
 writes ONE existing fact by id — PATCH, supersede, approve, dismiss, DELETE)
-require the owner admin token ALWAYS, even on loopback (#46 v2/v3) — see
+require the owner admin token ALWAYS, even on loopback (admin-gate v2/v3) — see
 `_admin_auth` below. That is a stricter, separate check from the
 DNS-rebinding/non-loopback middleware further down, which still governs the
 rest of the surface unchanged.
 
 The admin UI authenticates via a `POST /login` + httpOnly session-cookie flow
-(#46 v3), not a token embedded in the page: v2 served the real admin token to
+(admin-gate v3), not a token embedded in the page: v2 served the real admin token to
 ANY unauthenticated `GET /`, which was the same bypass one hop removed — any
 loopback caller could fetch the page, read the token, then call the gated
 endpoints. `GET /` now serves the real UI ONLY once the browser already holds
 a valid session cookie; otherwise it gets a locked page with nothing to leak.
 
 The session cookie holds an OPAQUE, high-entropy, server-side session id —
-NOT the admin bearer token itself (#46 v4). v3 set `mm_admin` to the real
+NOT the admin bearer token itself (admin-gate v4). v3 set `mm_admin` to the real
 token; `HttpOnly` stopped page JS from reading it, but any same-origin request
 still carried a reusable, non-expiring, non-revocable credential — a copied
 cookie was forever equivalent to the real token, and "logout" could only ever
@@ -30,7 +30,7 @@ random id server-side, logout pops it (true revocation), and every check
 rejects an expired id. The MCP admin server keeps using the real bearer token
 directly (`Authorization` header) — untouched by any of this.
 
-OWNER PASSWORD (#51 slice 1): the everyday browser login is now a durable
+OWNER PASSWORD: the everyday browser login is now a durable
 PASSWORD, not the process's admin token. `POST /login` checks the password
 against a memory-hard scrypt verifier (see `auth.py`) persisted in the durable
 store, so it survives restarts — no more hunting the terminal for a token after
@@ -151,7 +151,7 @@ class SupersedeBody(BaseModel):
 
 class QuarantineBody(BaseModel):
     # reason is REQUIRED and non-empty: a fact pulled out of canon has to say
-    # why, or the review queue is a pile of rows nobody can adjudicate (#72).
+    # why, or the review queue is a pile of rows nobody can adjudicate.
     ids: list[int]
     reason: str = Field(min_length=1)
 
@@ -168,7 +168,7 @@ class WebAuthnFinishBody(BaseModel):
 class RecallBody(BaseModel):
     query: str = ""
     # 50, not 500: recall is a retrieval aid, and an unbounded top-N over an
-    # empty query is a whole-ledger export primitive (#56). Nothing legitimate
+    # empty query is a whole-ledger export primitive. Nothing legitimate
     # asks for hundreds of facts in one reach.
     limit: int = Field(10, ge=1, le=50)
     include_superseded: bool = False
@@ -180,7 +180,7 @@ class RecallBody(BaseModel):
 # The exact recall projection the contract documents (docs/API.md "POST /recall").
 # recall.recall() returns whole ledger rows because internal callers want them;
 # the HTTP surface must not, since /recall answers unauthenticated loopback
-# callers by design. Add a field here only by amending the contract too (#56).
+# callers by design. Add a field here only by amending the contract too.
 RECALL_FIELDS = ("id", "content", "event_date", "confidence",
                  "origin_agent", "score")
 
@@ -257,7 +257,7 @@ def _ts(iso: str | None) -> float | None:
 LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 # The ONLY paths a browser may reach unauthenticated on a trusted (tailnet)
-# host: the lock screen and the flows that mint a session (#83). Everything
+# host: the lock screen and the flows that mint a session. Everything
 # else there needs the bearer token or a live admin session, so no anonymous
 # tailnet caller ever reaches fact data. `/enroll` and `/reset` still demand
 # the recovery secret in their own bodies — they are listed here because a
@@ -270,7 +270,7 @@ LOGIN_SURFACE = {"/", "/login", "/logout", "/enroll", "/reset",
                  "/webauthn/login/options", "/webauthn/login"}
 
 
-# Benchmark disposability sentinel (#90 slice 3). A THROWAWAY data dir that the
+# Benchmark disposability sentinel. A THROWAWAY data dir that the
 # benchmark harness provisions carries this file, holding a fresh random token
 # the harness itself wrote. `GET /v1/disposable-identity` reads it from the data
 # dir THIS instance actually serves and echoes the token back, so developer
@@ -363,33 +363,33 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Embedding-space guard (#60): a changed embedding model drops every
     # stored vector and refills in the background; never mixes spaces.
     embeddings.start_reembed_if_needed(settings)
-    # Warm the integrity verdict at startup (#79): the one place the full
+    # Warm the integrity verdict at startup: the one place the full
     # quick_check scan runs synchronously, so no live health probe — and
     # therefore no chat round awaiting one — ever pays for it.
     db.integrity_verdict(settings)
 
-    # The owner admin token for EXACT-ROW endpoints (#46 v2): if MEMORY_AUTH_TOKEN
+    # The owner admin token for EXACT-ROW endpoints (admin-gate v2): if MEMORY_AUTH_TOKEN
     # is configured, that's the token — a stable value across restarts, which is
     # what a persistently-registered MCP session needs. Otherwise a fresh random
     # token is minted for this process's lifetime. This is the ONLY credential
     # the MCP admin server / curl ever uses (Authorization: Bearer, unchanged by
     # everything below). Restart-to-rotate is deliberate.
     #
-    # #51 slice 1 gives it a SECOND job and takes one away: it is no longer the
+    # The password-login slice gives it a SECOND job and takes one away: it is no longer the
     # everyday browser-login secret (that's now the durable owner password), but
     # it IS the out-of-band RECOVERY SECRET that gates first-run enrollment and
     # password reset (POST /enroll, POST /reset). Same value, narrower everyday
     # role: proof-of-owner for setting a password, never the password itself.
     app.state.admin_token = settings.auth_token or secrets.token_urlsafe(32)
 
-    # Server-side session store for the BROWSER path (#46 v4): sid -> expiry
+    # Server-side session store for the BROWSER path (admin-gate v4): sid -> expiry
     # (unix epoch). The cookie holds only this opaque, random sid — never the
     # admin token — so a copied cookie is a revocable, expiring capability, not
     # a standing credential equivalent to the token itself. In-memory and
     # per-process on purpose: a restart is a fresh, empty store, so every
     # browser session must re-authenticate (matches the token's own restart
     # behavior when unconfigured, and keeps this out of the ledger entirely —
-    # no schema, no persistence, nothing for #46's "no ledger mutation" scope
+    # no schema, no persistence, nothing for the admin-gate work's "no ledger mutation" scope
     # to touch).
     app.state.admin_sessions = {}
     # Exposed on app.state (not just a closure local) so tests can inspect/
@@ -452,10 +452,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     #    Authorization: Bearer <MEMORY_AUTH_TOKEN>. No token configured means
     #    strictly loopback, no exceptions.
     #
-    # 3. TRUSTED HOSTS (#83): a browser cannot attach an Authorization header
+    # 3. TRUSTED HOSTS: a browser cannot attach an Authorization header
     #    to a navigation, so rule 2 alone made the owner's own phone — over
     #    the tailnet, the one sanctioned non-loopback path — unable to reach
-    #    even the lock screen, leaving #51's password gate unreachable from
+    #    even the lock screen, leaving the owner password gate unreachable from
     #    the device it exists for. A host the operator explicitly names in
     #    `trusted_hosts` therefore admits the BROWSER surface, with the
     #    password/session flow as the gate: a live admin session passes, and
@@ -518,7 +518,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return _session_ok(request.cookies.get(ADMIN_COOKIE, ""))
 
     def _admin_auth(request: Request):
-        """The stricter, ALWAYS-enforced gate for exact-row endpoints (#46 v2):
+        """The stricter, ALWAYS-enforced gate for exact-row endpoints (admin-gate v2):
         list/read raw facts, the review queue, and every verb on one existing
         fact by id (edit, supersede, approve, dismiss, delete). Loopback earns
         NO exception here — that's precisely the bypass this closes.
@@ -528,13 +528,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
           the real owner-configured/minted token directly. Unaffected by
           anything below.
         - The `mm_admin` session cookie — an OPAQUE, random, server-tracked
-          session id (#46 v4), not the token itself, set only by POST /login
+          session id (admin-gate v4), not the token itself, set only by POST /login
           after the owner supplies the token. A copied cookie is therefore a
           bounded, revocable capability (expires; dies instantly on logout),
           never a standing equivalent of the real credential.
         A sandboxed process reaching the API directly, with no token and no
         valid session, is refused regardless of host — including for `GET /`
-        itself, which hands out neither (#46 v3: embedding the token in the
+        itself, which hands out neither (admin-gate v3: embedding the token in the
         page for every caller was the same bypass one hop removed)."""
         if not _admin_ok(request):
             raise HTTPException(401, "owner token required for exact fact/review "
@@ -564,7 +564,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # Deliberately minimal and dependency-free: no token, no verifier, no
         # ledger data, nothing but a form. Shown to any caller that hasn't
         # authenticated — including a sandboxed process making a bare GET / —
-        # so there is NOTHING here for #46 v3's bypass to read. The recovery
+        # so there is NOTHING here for the admin-gate v3 bypass to read. The recovery
         # secret and the password verifier NEVER appear in this HTML (#51),
         # and neither does anything about a passkey beyond "one exists for
         # this origin" (#27) — no credential id, no public key.
@@ -594,7 +594,7 @@ small{color:#a1a1aa}
 <p>This page holds your durable memory — exact facts, review queue, edit/delete.</p>
 """
         if not enrolled:
-            # First run (or an install predating #51): no password exists yet.
+            # First run (or an install predating the owner password): no password exists yet.
             # Setting one requires the RECOVERY SECRET — the token printed to
             # the terminal at startup, or your MEMORY_AUTH_TOKEN. That proof
             # stops any other process on this machine from enrolling itself in.
@@ -696,7 +696,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
     def _mint_session_redirect():
         # Mint a FRESH random session id (never derived from any client-supplied
         # value — closes session fixation), record its expiry server-side, set
-        # ONLY that opaque id as an httpOnly, SameSite=Strict cookie (#46 v4:
+        # ONLY that opaque id as an httpOnly, SameSite=Strict cookie (admin-gate v4:
         # the cookie is not the bearer token), and redirect to `/` so nothing
         # sensitive lingers in the address bar or history.
         sid = secrets.token_urlsafe(32)
@@ -762,7 +762,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
     @app.post("/login", include_in_schema=False)
     def login(password: str = Form(...)):
         # The everyday owner login: the durable PASSWORD, checked against the
-        # scrypt verifier (#51). The admin token is deliberately NOT accepted
+        # scrypt verifier. The admin token is deliberately NOT accepted
         # here — it is the recovery secret for enroll/reset, never the everyday
         # login. Before enrollment there is nothing to check against, so login
         # simply fails and the locked page offers the enrollment form. A wrong
@@ -801,7 +801,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
     def logout(request: Request):
         # TRUE server-side revocation: the sid is deleted from the store, so
         # this exact instant invalidates every copy of the cookie anywhere —
-        # not just the browser that clicked Log out (#46 v4; v3's cookie WAS
+        # not just the browser that clicked Log out (admin-gate v4; v3's cookie WAS
         # the token, so "logout" could only ever clear one browser's copy,
         # never revoke a cookie an attacker had already captured).
         sid = request.cookies.get(ADMIN_COOKIE, "")
@@ -1015,7 +1015,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
     @app.get("/v1/health")
     def health():
         h = db.health(settings)
-        # Aggregate, in-memory drop-by-reason counts (#66) — an operational
+        # Aggregate, in-memory drop-by-reason counts — an operational
         # signal only ("is the builder-process filter firing a lot?"), never a
         # record of what was dropped. Lives in `detail`, which is explicitly
         # documented as non-contractual and may change without a version bump.
@@ -1039,7 +1039,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
 
     @app.get("/v1/disposable-identity")
     def disposable_identity():
-        # Benchmark disposability probe (#90 slice 3). Read-only, loopback-safe,
+        # Benchmark disposability probe. Read-only, loopback-safe,
         # and content-free: it reflects ONLY the benchmark token found in the
         # data dir this instance serves — never the auth token, an API key, the
         # data-dir path, or any ledger content — and it never creates the
@@ -1087,9 +1087,9 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
 
     @app.post("/v1/search", dependencies=[Depends(_admin_auth)])
     def search(body: SearchBody):
-        # Owner-gated (#125): verbatim transcript snippets are a wider
+        # Owner-gated: verbatim transcript snippets are a wider
         # projection than /v1/recall, which was deliberately narrowed to
-        # RECALL_FIELDS under #56. Recall stays the open chat-loop surface;
+        # RECALL_FIELDS. Recall stays the open chat-loop surface;
         # search is a human/admin surface. The MCP search tool reads the
         # database directly and is unaffected.
         c = con()
@@ -1158,7 +1158,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
     @app.post("/v1/facts/quarantine", dependencies=[Depends(_admin_auth)])
     def quarantine_facts(body: QuarantineBody):
         # The missing third treatment for a fact already accepted as canon
-        # (#72). DELETE is destructive; supersede asserts a replacement fact
+        #. DELETE is destructive; supersede asserts a replacement fact
         # that a malformed row doesn't have. This pulls the fact out of recall
         # and the summary, keeps it in the ledger, and files it for review with
         # a reason. Reversible with /approve. Unknown or already-quarantined
@@ -1238,7 +1238,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
 
     @app.post("/v1/review/dismiss-all", dependencies=[Depends(_admin_auth)])
     def dismiss_all_review():
-        # Bulk twin of /v1/facts/{id}/dismiss (#66): clears the whole review
+        # Bulk twin of /v1/facts/{id}/dismiss: clears the whole review
         # queue in one call, same non-destructive semantics — every affected
         # fact stays quarantined and in the ledger, just leaves the queue, and
         # any one of them is reversible with /approve. Meant for clearing a
@@ -1667,7 +1667,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         # was handing back SELECT * — content_hash, conversation_id,
         # source_message_id, quarantine_reason and friends — to a caller that
         # needs none of them. /recall is deliberately open (every chat round
-        # uses it), so what it projects IS the security boundary (#56).
+        # uses it), so what it projects IS the security boundary.
         return {"facts": [_recall_out(f) for f in facts]}
 
     @app.get("/v1/summary")
@@ -1748,7 +1748,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
 
     @app.get("/v1/jobs/{job_id}", dependencies=[Depends(_admin_auth)])
     def job_status(job_id: str):
-        # Owner-gated (#125): a job result can embed whole fact rows (a
+        # Owner-gated: a job result can embed whole fact rows (a
         # consolidate run returns them), so reading jobs is exact-row
         # access. Callers that fire-and-forget /v1/distill are unaffected.
         job = jobs.get(job_id)
@@ -1831,7 +1831,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
 
     @app.get("/v1/viz/landscape")
     def viz_landscape():
-        # The one always-current 3D scene (#40). Geometry only; self-sufficient —
+        # The one always-current 3D scene. Geometry only; self-sufficient —
         # triggers the projection build when cold, then returns the biome data.
         pending = _projection_pending()
         if pending:
@@ -1866,10 +1866,10 @@ def main():
     app = create_app(settings)
     # The ONLY place the admin token is ever printed: this process's own
     # stdout (the owner's terminal that ran start.sh), never an HTTP response
-    # (#46 v3) and never a file. A sandboxed session sharing this machine's
+    # (admin-gate v3) and never a file. A sandboxed session sharing this machine's
     # filesystem/network has no route to a live terminal's stdout.
     #
-    # #51 slice 1: this value is the RECOVERY SECRET, not the everyday login.
+    # Since the password-login slice: this value is the RECOVERY SECRET, not the everyday login.
     # First run, it enrolls your durable password; after that you log in with
     # the password and only need this again to reset it (or for MCP/curl Bearer).
     kind = "configured MEMORY_AUTH_TOKEN" if settings.auth_token else "generated for this run — changes on restart"

--- a/memory_service/auth.py
+++ b/memory_service/auth.py
@@ -1,4 +1,4 @@
-"""Owner password — a durable, memory-hard verifier for the admin UI (#51 slice 1).
+"""Owner password — a durable, memory-hard verifier for the admin UI.
 
 Before this, the browser "login" accepted the process's admin token (the value
 printed to the terminal at startup, or `MEMORY_AUTH_TOKEN`). That token is
@@ -36,7 +36,7 @@ import secrets
 from . import db
 
 # The durable settings key holding the owner-password verifier JSON. Absent =
-# not yet enrolled (a fresh install, or one that predates #51 slice 1).
+# not yet enrolled (a fresh install, or one that predates the owner password).
 SETTING_KEY = "owner_password_verifier"
 
 # scrypt cost parameters. n MUST be a power of two; memory use is ~128*r*n

--- a/memory_service/captions.py
+++ b/memory_service/captions.py
@@ -1,4 +1,4 @@
-"""Machine-generated image descriptions, so photos stop being invisible (#107).
+"""Machine-generated image descriptions, so photos stop being invisible.
 
 An image attachment stores its bytes but ``extract_text`` yields "" — so search,
 mining, and recall never see it, and a conversation held *about* photos leaves

--- a/memory_service/config.py
+++ b/memory_service/config.py
@@ -19,7 +19,7 @@ class Settings(BaseModel):
     port: int = 8901
     auth_token: str | None = None          # required to bind non-loopback
     # Hostnames where the BROWSER surface is admitted with the password/session
-    # flow as the gate — in practice one Tailscale tailnet name (#83). Empty
+    # flow as the gate — in practice one Tailscale tailnet name. Empty
     # (the default) keeps the strict loopback-or-bearer-token rule exactly as
     # it was: this can only ever widen access for an operator who opts in by
     # naming their own host. See api.py's trust middleware and SECURITY.md.
@@ -35,7 +35,7 @@ class Settings(BaseModel):
     # identity & models
     user_name: str = "User"
     miner_model: str = "claude-haiku-4-5"  # any lab's cheap model; routed by name
-    # Model for image captions (#107). Empty = use miner_model. Set this only
+    # Model for image captions. Empty = use miner_model. Set this only
     # if your miner is a text-only model: captions need a vision-capable one.
     caption_model: str = ""
     # The summary is the most-read artifact in the system (every model, every
@@ -62,7 +62,7 @@ class Settings(BaseModel):
     # keyword-only until that completes.
     embedding_base_url: str = ""
     memory_summary_words: int = 2000
-    # (`summary_emergent_topics` lived here until 2026-07-26 (#13). Emergent
+    # (`summary_emergent_topics` lived here until 2026-07-26. Emergent
     # middle sections graduated from experiment to simply how the profile is
     # written, so the knob is gone; an old value left in config.local.json is
     # ignored, like any unknown key. See summary.py for how to revert.)

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -133,7 +133,7 @@ CREATE TABLE IF NOT EXISTS access_log(
 );
 CREATE INDEX IF NOT EXISTS idx_access_log_ts ON access_log(ts);
 
--- Machine-generated image descriptions (#107). Their OWN append-only table on
+-- Machine-generated image descriptions. Their OWN append-only table on
 -- purpose: the attachments row is part of the episodic record and no module
 -- may UPDATE it (tested) — new derived information gets appended alongside,
 -- never written into the original. PRIMARY KEY = one caption per attachment,
@@ -413,7 +413,7 @@ def start_backup_scheduler(settings) -> threading.Event:
     return stop
 
 
-# ---- integrity verdict cache (#79) ----
+# ---- integrity verdict cache ----
 #
 # `PRAGMA quick_check` scans the whole database file (hundreds of ms on a tens-of-MB file, growing
 # with it), and /v1/health used to run it inline — which put a file-integrity
@@ -505,7 +505,7 @@ def health(settings) -> dict:
         "journal_mode": journal,
         "integrity": integrity,
         # non-contractual (rides in /v1/health's `detail`): when the cached
-        # verdict was computed, so an operator can see its age (#79)
+        # verdict was computed, so an operator can see its age
         "integrity_checked_at": _integrity["checked_at"] or None,
         "size_bytes": settings.db_path.stat().st_size if settings.db_path.exists() else 0,
         "facts": dict(f),

--- a/memory_service/embeddings.py
+++ b/memory_service/embeddings.py
@@ -18,7 +18,7 @@ import os
 import struct
 import threading
 
-# Module-top import (#78): the lazy in-function import cost ~370ms on the
+# Module-top import: the lazy in-function import cost ~370ms on the
 # first recall of a process — importing is free of any key requirement, so
 # there is no reason to defer it into the request path.
 from openai import OpenAI
@@ -38,7 +38,7 @@ def available(settings=None) -> bool:
     return settings is not None and bool(_base_url(settings))
 
 
-# One client per process (#78): a fresh OpenAI() per call meant a new
+# One client per process: a fresh OpenAI() per call meant a new
 # TCP+TLS handshake to api.openai.com on EVERY recall — a large share of the
 # chat client's measured ~0.9s ambient-recall wait. The SDK client is
 # thread-safe and pools connections; ledger's embed threads share it too.
@@ -91,7 +91,7 @@ def cosine(a, b) -> float:
 
 
 def unit(vec):
-    """Unit-normalized copy of `vec`, or None for a zero vector (#78)."""
+    """Unit-normalized copy of `vec`, or None for a zero vector."""
     n = math.sqrt(math.sumprod(vec, vec))
     return [x / n for x in vec] if n else None
 
@@ -99,7 +99,7 @@ def unit(vec):
 def cosine_unit(u, b) -> float:
     """cosine(q, b) where `u` is the already-unit-normalized q. A recall
     scan compares ONE query against every fact; recomputing the query's own
-    norm per fact was ~a third of the scan (#78). Same result as cosine()
+    norm per fact was ~a third of the scan. Same result as cosine()
     up to float rounding."""
     nb = math.sqrt(math.sumprod(b, b))
     return math.sumprod(u, b) / nb if nb else 0.0

--- a/memory_service/episodic.py
+++ b/memory_service/episodic.py
@@ -76,7 +76,7 @@ def attachments_for_conversation(con, conversation_id: int) -> dict[str, list[di
     """message_external_id -> attachment rows (no bytes), for the mining view."""
     out: dict[str, list[dict]] = {}
     for r in con.execute(
-            # A machine caption (#107) stands in for extracted text when the
+            # A machine caption stands in for extracted text when the
             # attachment has none (images): the attachments row itself is never
             # updated, so the overlay happens here, at read time.
             "SELECT a.message_external_id, a.filename, a.mime, "

--- a/memory_service/ledger.py
+++ b/memory_service/ledger.py
@@ -14,7 +14,7 @@ from . import db
 
 log = logging.getLogger("memory_service.ledger")
 
-# `#1990` / `#216, 1394 2039` — an id lookup rather than a content search (#74).
+# `#1990` / `#216, 1394 2039` — an id lookup rather than a content search.
 # The `#` is what disambiguates: a bare `1990` is a legitimate thing to search
 # the TEXT for (a year, a figure), and silently reading it as an id would make
 # content search unpredictable.
@@ -96,7 +96,7 @@ def add_fact(con, content: str, settings, *, source: str = "user",
     memory by phrasing a sentence well. The origin gate outranks it.
 
     `dedupe_in_conversation` is a NARROW write-time guard for the mining path
-    (#36): when set, re-adding a fact whose normalized content already exists
+: when set, re-adding a fact whose normalized content already exists
     (non-superseded) for the SAME conversation is a no-op returning the existing
     row. It stops a re-run that re-mines the same messages from multiplying facts
     — the case the in-process distill lock cannot cover (a crash/restart between
@@ -184,7 +184,7 @@ def list_facts(con, status: str = "valid", query: str | None = None,
         params.extend(ids)
         # An explicit id list is a request for exactly those rows, so it must
         # never be silently trimmed by the page size — the caller would think
-        # the missing ids simply don't exist (#74).
+        # the missing ids simply don't exist.
         limit = max(limit, len(ids))
     elif query:
         where.append("content LIKE ?")
@@ -250,7 +250,7 @@ def quarantine(con, fact_id: int, reason: str) -> bool:
 
 
 def quarantine_many(con, fact_ids, reason: str) -> dict:
-    """Bulk `quarantine`, for facts ALREADY accepted as canon (#72).
+    """Bulk `quarantine`, for facts ALREADY accepted as canon.
 
     `quarantine` above is reached only at ingest, by the wall. Nothing could
     quarantine a fact that had already been accepted — leaving `DELETE`
@@ -306,7 +306,7 @@ def dismiss_all(con) -> int:
     reviewed-and-kept-out in one action. Exact same semantics as one-at-a-time
     dismiss (quarantined, non-destructive, reversible via `approve`) — just
     applied to the whole queue at once, for clearing a backlog made stale by a
-    filtering fix (#66) without clicking through each row. Human-only (API/UI).
+    filtering fix without clicking through each row. Human-only (API/UI).
     Returns the number of facts moved out of the queue."""
     cur = con.execute(
         "UPDATE facts SET review_dismissed_at=? "

--- a/memory_service/llm.py
+++ b/memory_service/llm.py
@@ -19,7 +19,7 @@ class MissingKeyError(RuntimeError):
     pass
 
 
-# One client per process per provider (#78, mirroring embeddings.py): a fresh
+# One client per process per provider (mirroring embeddings.py): a fresh
 # SDK client per call paid a new TLS handshake for every mining/summary call.
 # Both SDK clients are thread-safe; jobs threads share them. The key checks
 # below still run FIRST, so keyless behavior (loud MissingKeyError, no

--- a/memory_service/mcp_admin_server.py
+++ b/memory_service/mcp_admin_server.py
@@ -1,4 +1,4 @@
-"""MCP admin adapter — READ-ONLY, authenticated, owner-scoped (#46).
+"""MCP admin adapter — READ-ONLY, authenticated, owner-scoped.
 
 For a session that needs to confirm or remediate exact ledger rows (ids,
 approval/quarantine status, review-queue membership, event/source dates) —
@@ -20,7 +20,7 @@ not an addition to it:
   delete / save tool exists here, matching mcp_server.py's write-gate
   asymmetry: this surface can look, never touch.
 - ALWAYS sends a bearer token (MEMORY_AUTH_TOKEN), even against loopback — and
-  as of contract 1.1 (#46 v2) the service itself enforces this: `GET /v1/facts`
+  as of contract 1.1 (admin-gate v2) the service itself enforces this: `GET /v1/facts`
   and `GET /v1/review` require a matching owner admin token from ANY caller,
   loopback included, so this is no longer a client-side-only convention (v1
   of this module held itself to that bar voluntarily; a sandboxed process

--- a/memory_service/mcp_server.py
+++ b/memory_service/mcp_server.py
@@ -88,7 +88,7 @@ def save_memory(content: str, event_date: str = "") -> str:
     becoming part of their memory. Optionally pass event_date as YYYY-MM-DD when
     the fact is about a specific past/future date rather than today."""
     # Drop, don't quarantine, obvious system/AI-tooling or builder-process noise
-    # (#66) — mcp:* writes are quarantined by provenance regardless of content,
+    # — mcp:* writes are quarantined by provenance regardless of content,
     # so without this check even blatant process chatter ("merged PR #12, CI is
     # green") would land straight in the human review queue. Quarantine means
     # an uncertain, potentially durable fact about the user, never an audit
@@ -123,7 +123,7 @@ def save_memory(content: str, event_date: str = "") -> str:
 def _format_summary(s: dict) -> str:
     """Stamp the profile prose with when it was generated. A stale summary reads
     as authoritative, so the consumer is told the age and reminded to verify
-    time-sensitive / active-thread status with recall (see issue #27)."""
+    time-sensitive / active-thread status with recall."""
     if not s.get("summary"):
         return "No memory summary yet."
     ts = s.get("generated_at")

--- a/memory_service/mining.py
+++ b/memory_service/mining.py
@@ -21,7 +21,7 @@ from . import captions, episodic, ledger, llm, persons, recall, summary, walls
 # `mined_upto` watermark once, then mines everything after it. Two runs for the
 # SAME conversation overlapping in this process would both read the same
 # watermark and re-mine the same messages, multiplying facts (the amplifier in
-# #36). We serialize per conversation with a non-blocking guard: if a run is
+# the meta-conversation flood). We serialize per conversation with a non-blocking guard: if a run is
 # already in flight, the second returns immediately — the in-flight run advances
 # the watermark and covers those messages. In-process is sufficient: the service
 # is a single port-guarded instance and /v1/distill is its only caller.
@@ -43,14 +43,14 @@ _SUPERSEDES_RE = re.compile(r"supersedes\s*=\s*\[?\s*(\d+(?:\s*,\s*\d+)*)\s*\]?"
 _IMPORTANCE_RE = re.compile(r"importance\s*=\s*(\d{1,2})", re.I)
 _EVENT_RE = re.compile(r"event\s*=\s*(\d{4}-\d{2}-\d{2})", re.I)
 # The message this fact was derived from, as the [msg N] label the model echoes
-# back. It scopes event-date grounding to ONE turn's text (see #33) so a date
+# back. It scopes event-date grounding to ONE turn's text so a date
 # living elsewhere in the chunk can't ground a fact it has nothing to do with.
 _SRC_RE = re.compile(r"src\s*=\s*(\d+)", re.I)
 
 # Explicit calendar dates are recognised by `walls.explicit_dates` — ONE
 # definition, because the same question ("is this date literally in the text?")
 # gates two different things: the event date honoured below, and the temporal
-# wall that catches a date invented in a fact's prose (#38). We only ever honour
+# wall that catches a date invented in a fact's prose. We only ever honour
 # a model-supplied event date that is literally anchored in the source — never a
 # relative ("last Tuesday") or vague ("a couple weeks ago") phrase, and never a
 # date the model invented. Inventing a date is exactly the fabrication this
@@ -93,7 +93,7 @@ def _grounded_event_date(model_date: str | None, source_text: str,
 def _retry_importance(fact: str, settings) -> int | None:
     """Reissue ONE fact whose importance= tag the miner omitted or malformed,
     asking explicitly for the missing score before we fall back to quarantine
-    (#69). The first-pass omission rate is high enough (the smaller utility
+. The first-pass omission rate is high enough (the smaller utility
     model drops a required tag under the heavier event=/src= grammar) that
     quarantining on sight would flood the review queue; a single cheap re-ask
     recovers the common case where the fact itself was fine and only the tag
@@ -229,7 +229,7 @@ MSG_CHARS = 20_000      # a single pasted document is truncated for mining —
                         # the episodic record keeps it verbatim; only this
                         # pass reads a bounded view
 
-# #71: the supersede-candidate list used to be ONLY the 250 newest valid facts
+# The supersede-candidate list used to be ONLY the 250 newest valid facts
 # by insertion id (ledger.list_facts orders id DESC) — a structural blind
 # spot, not a tuning knob. A fact contradicted by new information but never
 # re-mentioned since simply aged out of the window and became permanently
@@ -252,7 +252,7 @@ def _msg_body(m: dict) -> str:
     message it traveled with — a pasted document's facts are as real as typed
     ones. The episodic record keeps every byte; this pass reads a bounded view.
     This is also the text a fact's event date is grounded against once the fact
-    is bound to its source message (#33)."""
+    is bound to its source message."""
     c = m["content"]
     for a in m.get("attachments") or []:
         if a.get("extracted_text"):
@@ -282,7 +282,7 @@ def _transcript(messages: list[dict], user_name: str) -> str:
     [msg N] label (N = 1-based position in this window). The label is what lets
     the extractor attribute each fact back to the single turn it came from: the
     model echoes it as src=N, and that binding is what scopes event-date
-    grounding to one message instead of the whole chunk (#33)."""
+    grounding to one message instead of the whole chunk."""
     return "\n\n".join(
         f"[msg {i}] {_speaker(m, user_name)}: {_msg_body(m)}"
         for i, m in enumerate(messages, start=1))
@@ -313,14 +313,14 @@ def distill(con, settings, source_app: str, conversation_external_id: str,
     if not lock.acquire(blocking=False):
         # Another distill for THIS conversation is already running in-process;
         # letting this one proceed would re-mine the same messages and multiply
-        # facts (#36). Skip — the in-flight run covers these messages.
+        # facts. Skip — the in-flight run covers these messages.
         return {"added": 0, "quarantined": 0, "skipped_locked": True}
     try:
         conv = episodic.get_conversation(con, source_app, conversation_external_id)
         if not conv:
             raise LookupError("unknown conversation")
         added = quarantined = deduped = refused = deferred = 0
-        # Images first (#107): captions land in extracted_text, which the
+        # Images first: captions land in extracted_text, which the
         # attachment view below reads — so photo content mines exactly like a
         # pasted document's. Any caption failure skips that image and never
         # blocks the text mining that follows.
@@ -344,12 +344,12 @@ def distill(con, settings, source_app: str, conversation_external_id: str,
             summary.regenerate(con, settings)
         result = {"added": added, "quarantined": quarantined}
         if deduped:
-            # Only surfaced when a re-mine was actually collapsed (#36) — keeps
+            # Only surfaced when a re-mine was actually collapsed — keeps
             # the common return shape unchanged for existing callers/tests.
             result["deduped"] = deduped
         if refused:
             # Same shape rule as deduped: present only when a backdated
-            # supersession was actually refused (#120).
+            # supersession was actually refused.
             result["refused_supersede"] = refused
         if deferred:
             result["deferred_supersede"] = deferred
@@ -385,7 +385,7 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
     recent = ledger.list_facts(con, status="valid", limit=250)
     candidates = {f["id"]: f for f in recent}
     try:
-        # Reach beyond the recency window (#71): facts relevant to THIS
+        # Reach beyond the recency window: facts relevant to THIS
         # chunk's topics, however old, so a directly contradicted fact is
         # still offered as a supersede target. Merge, don't replace — the
         # recency window still gives the model everything freshly discussed,
@@ -430,7 +430,7 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         "Not passing moods.\n"
         "The test is DURABILITY (still true in ~6 months), not topic — keep durable "
         "relationships and goals; drop transient feelings and chit-chat.\n"
-        "PROJECT / BUILDER CONVERSATIONS (#66) get a stricter two-level rule, "
+        "PROJECT / BUILDER CONVERSATIONS get a stricter two-level rule, "
         "because this ledger is biography, not an engineering log — the full "
         "transcript already exists, searchable, for anyone who needs the technical "
         "detail:\n"
@@ -541,19 +541,19 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
             # Self-reference to this memory system's machinery or the AI tooling
             # itself — not biography about the user, so it is never extracted
             # (dropping keeps the review queue from flooding when a conversation
-            # is ABOUT the memory system — #36). The verbatim message survives in
+            # is ABOUT the memory system). The verbatim message survives in
             # the episodic record, so nothing is actually lost.
             walls.record_drop("system-meta")
             continue
         if walls.is_builder_process(fact):
             # Ordinary engineering-process/execution chatter about building a
             # project — PR/issue/CI mechanics, implementation minutiae, transient
-            # UI styling (#66). Same reasoning as is_system_meta: not biography,
+            # UI styling. Same reasoning as is_system_meta: not biography,
             # nothing for a human to review, and the verbatim message still
             # survives in the episodic record.
             #
             # This is a keyword-matching BACKSTOP, not the primary defense — the
-            # live-evidence gap in #66's reopening showed deep technical/
+            # live-evidence gap in the engineering-chatter wall's reopening showed deep technical/
             # architecture reasoning (cache-invalidation analysis, root-causing)
             # trips no keyword here at all. The real fix is upstream, in the
             # extraction prompt itself: the model is asked not to propose that
@@ -571,7 +571,7 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         # always in the profile) and only the owner may grant that — a batch
         # scoring hiccup must never be able to mint permanence.
         #
-        # importance is REQUIRED, never optional (#69). After the output grammar
+        # importance is REQUIRED, never optional. After the output grammar
         # gained event= and src= tags (2026-07-15), the utility model began
         # dropping the importance= tag under the heavier load, and this parser
         # accepted the omission and stored NULL. Summary selection reads NULL as
@@ -597,7 +597,7 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         # the event date outright and fall back to conversation time. We never
         # ground against the latest turn's text as a consolation, because a date
         # that happens to sit in that turn could still borrow onto an unrelated
-        # fact — a narrower re-opening of the exact #33 hole.
+        # fact — a narrower re-opening of the exact date-borrowing hole.
         bound = idx_to_msg.get(int(src.group(1))) if src else None
         repair_refused = None
         if bound is None and line_no in src_repairs:
@@ -631,7 +631,7 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
             # support.
             source_message_id = None
         # The walls (grounding/source-trust/scope) still read the whole chunk:
-        # a fact may legitimately synthesise across turns, and #33 is about the
+        # a fact may legitimately synthesise across turns, and the date-borrowing fix is about the
         # event date only — narrowing the walls here would be scope creep.
         flags = walls.check(fact, source_text, allow)
         # #31: source-trust for WHO SPOKE. A fact bound to a guest's turn, an
@@ -665,7 +665,7 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
         if speaker_flag:
             flags = flags + [speaker_flag]
         if importance is None:
-            # #69: still unscored AFTER the corrective retry — the backstop.
+            # Still unscored AFTER the corrective retry — the backstop.
             # Quarantine, don't silently trust.
             flags = flags + [
                 "importance: miner omitted or malformed importance= and did "
@@ -695,13 +695,13 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
                 if old_id not in valid_ids:
                     continue
                 if res["quarantined"]:
-                    # A held-for-review fact must not alter canon (#120): its
+                    # A held-for-review fact must not alter canon: its
                     # supersession intent is deferred to the human review pass
                     # (the queue's supersede action), never auto-applied from
                     # quarantine.
                     deferred += 1
                     continue
-                # An older claim never invalidates a newer one (#120). When
+                # An older claim never invalidates a newer one. When
                 # mining history (imported exports, late re-mines), this fact's
                 # grounded event date can precede the listed target's — the
                 # fact itself still lands above, event-dated and walled; only

--- a/memory_service/recall.py
+++ b/memory_service/recall.py
@@ -45,7 +45,7 @@ def recall(con, settings, query: str = "", limit: int = 10,
     except Exception:
         qvec = None
     # normalize the query ONCE — the scan compares it against every fact,
-    # and recomputing its norm per fact was ~a third of the scan (#78)
+    # and recomputing its norm per fact was ~a third of the scan
     qunit = embeddings.unit(qvec) if qvec is not None else None
     words = [w.lower() for w in query.split() if len(w) >= 3]
     now_ts = db.now()
@@ -75,7 +75,7 @@ def recall(con, settings, query: str = "", limit: int = 10,
         h = e.get("content_hash")
         if h and h in seen_hash:
             continue
-        # unpacked once in the scoring pass (#78); the fallback covers the
+        # unpacked once in the scoring pass; the fallback covers the
         # keyword-only path (no query vector), where facts may still carry
         # embeddings and paraphrase collapse must keep working
         ev = e.get("_vec")

--- a/memory_service/summary.py
+++ b/memory_service/summary.py
@@ -18,7 +18,7 @@ BUDGET_TOLERANCE = 1.2  # accept up to 20% over budget; beyond that, one rewrite
 
 
 def provenance_tag(fact: dict) -> str:
-    """Coarse, MECHANICALLY grounded provenance (#110) — never a guess at who
+    """Coarse, MECHANICALLY grounded provenance — never a guess at who
     specifically said something.
 
     - 'direct': origin_agent IS the literal 'user' sentinel (ledger.is_trusted
@@ -68,7 +68,7 @@ def get(con) -> dict:
         "summary": db.get_setting(con, "summary"),
         "generated_at": sources.get("generated_at"),
         "source_fact_ids": sources.get("fact_ids", []),
-        # Structured, per-fact provenance (#110) — a downstream consumer can
+        # Structured, per-fact provenance — a downstream consumer can
         # check who/what a claim traces back to WITHOUT trusting unlabelled
         # prose for attribution. Additive field: older summary_sources rows
         # (generated before this shipped) simply have none, so default empty
@@ -101,7 +101,7 @@ def regenerate(con, settings) -> str:
         # so the model can resolve temporal conflicts: when two entries disagree
         # about the same current-state or active-thread status, the later date
         # is the current one (see the latest-wins rule in the prompt).
-        # ...and its PROVENANCE tag (#110) — mechanically derived (see
+        # ...and its PROVENANCE tag — mechanically derived (see
         # provenance_tag), never a guessed speaker: 'direct' the owner said it
         # themselves, 'mined' it was distilled from conversation with no
         # recorded speaker, anything else is the raw origin_agent as written.
@@ -117,7 +117,7 @@ def regenerate(con, settings) -> str:
     # style) — see docs/REFERENCES.md.
     #
     # This shipped 2026-07-09 behind `summary_emergent_topics` as a reversible
-    # experiment and GRADUATED 2026-07-26 (#13): the flag is gone and this is
+    # experiment and GRADUATED 2026-07-26: the flag is gone and this is
     # simply how the profile is written. To revert, restore the fixed layout the
     # flag used to select:
     #     "under these markdown headings, including only sections that have
@@ -146,7 +146,7 @@ def regenerate(con, settings) -> str:
         "is the current one; state only that as current, and never assert an "
         "older, superseded status as if it still holds — mention it, if at all, "
         "only as past history. "
-        "PROVENANCE (#110 — read carefully, this is not optional): each entry's "
+        "PROVENANCE (read carefully, this is not optional): each entry's "
         "final bracket segment is its provenance tag. 'direct' means the owner "
         "stated it themselves. 'mined' means it was distilled from a "
         "multi-turn conversation — NO single speaker or turn is recorded for "
@@ -200,7 +200,7 @@ def regenerate(con, settings) -> str:
         except Exception:
             pass  # the verbose-but-complete draft is still a valid summary
     fact_ids = sorted(f["id"] for f in facts)
-    # Structured provenance (#110), persisted alongside fact_ids so a
+    # Structured provenance, persisted alongside fact_ids so a
     # downstream consumer can trace any claim back to what it actually traces
     # to — origin_agent and source kept RAW, never flattened into an invented
     # category — rather than trusting the prose tag alone.

--- a/memory_service/viz.py
+++ b/memory_service/viz.py
@@ -236,7 +236,7 @@ def attach_live(con, data):
     return {**data, "summary_ids": ids, "now": db.now()}
 
 
-# ---- Memory landscape (issue #40): the playful "shape of me" lens ----------
+# ---- Memory landscape: the playful "shape of me" lens ----------
 # Same discipline as the rest of this module: geometry only — ids, coordinates,
 # cluster indices, freshness scores, edge weights, timestamps. No fact text ever
 # leaves the ledger here. Every layer below is built from data that actually
@@ -244,12 +244,12 @@ def attach_live(con, data):
 # the payload (`notes`) rather than inventing it.
 
 LANDSCAPE_MAX_EDGES = 120  # keep the co-occurrence web readable, never a hairball
-# Palette is INDICES only — the client picks hues. The contract (issue #40): a
+# Palette is INDICES only — the client picks hues. The contract: a
 # colour distinguishes a cloud from its NEIGHBOURS; it is never a stable
 # topic→colour mapping. Greedy graph-colouring guarantees adjacent clouds
 # differ while reusing a small set.
 LANDSCAPE_PALETTE_N = 8
-# Clustering: k-means on the actual 3D projected coordinates (issue-#43 redesign
+# Clustering: k-means on the actual 3D projected coordinates (the 3D redesign
 # — the landscape is a rotatable 3D "biome", not a flattened 2D map). Grid
 # connected-components collapsed dense data (thousands of points → 2 blobs); flat
 # 2D k-means then bait-and-switched the 3D Replay space into a flat map. k-means
@@ -384,7 +384,7 @@ def _neighbour_colours(centroids):
 
 def _cooccurrence_edges(con, alive_ids):
     """Weighted edges from the access log: facts RECALLED TOGETHER. This is the
-    honest reading of issue #40's 'memories that keep surfacing together in the
+    honest reading of the landscape brief's 'memories that keep surfacing together in the
     same conversations' — two facts co-occur each time one recall returned both.
     Sparse until recall history accrues; absent entirely on a fresh ledger, and
     the client says so rather than drawing a fake web."""
@@ -408,7 +408,7 @@ def _cooccurrence_edges(con, alive_ids):
 
 
 def _sediment(con, coord_ids):
-    """Supersession strata (issue #40, past tense): for each current fact, the
+    """Supersession strata (the landscape brief, past tense): for each current fact, the
     chain of older facts it buried. Geometry only — id, when it was retired,
     importance, depth. Reading the buried TEXT stays a deliberate opt-in in the
     admin ledger; the append-only invariant means every layer is still there."""
@@ -443,7 +443,7 @@ def _sediment(con, coord_ids):
 
 
 def landscape_data(con):
-    """The memory landscape (#40): clouds + freshness + co-occurrence web +
+    """The memory landscape: clouds + freshness + co-occurrence web +
     sediment, all from the CACHED projection so it's cheap to re-serve. Returns
     {"status": "computing"} when the projection isn't built yet — the client
     polls, same as /v1/viz/embeddings."""

--- a/memory_service/walls.py
+++ b/memory_service/walls.py
@@ -9,12 +9,12 @@ The third, `is_system_meta`, is a DROP filter, not a quarantine: a "fact" that
 is about this memory system's own machinery or the AI tooling itself is not
 biography about the user at all, so there is nothing for a human to approve —
 holding it for review only floods the queue when a conversation happens to be
-ABOUT the memory system (the #36 failure mode). Such lines are never extracted.
+ABOUT the memory system (the meta-conversation failure mode). Such lines are never extracted.
 It is deliberately narrow — it matches system/AI-tooling *mechanics* vocabulary,
 never the generic words ("deployed", "the system", "committed") or product names
 a genuine career/project fact might legitimately carry.
 
-`is_builder_process` (#66) is a sibling DROP filter, same discipline, for a
+`is_builder_process` is a sibling DROP filter, same discipline, for a
 different flood: ordinary engineering/execution chatter about ANY project being
 built — PR/issue mechanics, code review and CI status, and transient UI
 styling/layout minutiae — none of which is durable biography about the user
@@ -74,7 +74,7 @@ _PERSONA_RE = re.compile(
 # generic verbs/nouns that appear in real user facts — "deployed", "committed
 # and push", "this app", "the system", "backfill", "memory service" — so a
 # career/project fact that merely mentions a product or a deploy is NOT dropped
-# and is judged by the grounding/source-trust walls like anything else (#36).
+# and is judged by the grounding/source-trust walls like anything else.
 #
 # The set is kept to terms with a near-zero false-positive rate on real
 # biography. Words that are common English or plausible in a work fact are
@@ -87,7 +87,7 @@ _SYSTEM_META_RE = re.compile(
     r"the extraction walls?|quarantin\w*|supersed\w*|the miner|mined?_upto|"
     r"consolidation (pass|sweep)|synthesis fact|PID \d)\b", re.I)
 
-# Builder-process / execution-chatter DROP vocabulary (#66) — engineering
+# Builder-process / execution-chatter DROP vocabulary — engineering
 # mechanics for ANY project being built, not specific to this memory system.
 # Same discipline as _SYSTEM_META_RE: near-zero false-positive rate on real
 # biography. Four clusters, each keyed to the issue's own examples:
@@ -210,11 +210,11 @@ def ungrounded_entities(fact: str, source_text: str, allowlist: set[str]) -> lis
     return missing
 
 
-# ── temporal grounding (#38) ─────────────────────────────────────────────────
+# ── temporal grounding ─────────────────────────────────────────────────
 #
 # Explicit calendar dates we recognise IN TEXT. One definition, two consumers:
 # mining grounds a model-supplied `event=` against it (a date is honoured only
-# when literally present — #30/#32/#33), and the temporal wall below uses it to
+# when literally present — the never-guess-dates rule), and the temporal wall below uses it to
 # catch a date asserted in the fact's PROSE that the source never wrote.
 _MONTHS = {
     "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
@@ -272,7 +272,7 @@ def explicit_dates(text: str) -> set:
 
 
 def ungrounded_temporal(fact: str, source_text: str) -> list[str]:
-    """Temporal claims in `fact` that `source_text` never makes (#38).
+    """Temporal claims in `fact` that `source_text` never makes.
 
     The grounding wall above checks proper nouns, so it never saw a date: a
     lower-case gloss like "the appointment is Saturday (tomorrow from the
@@ -432,14 +432,14 @@ def lexical_support(fact: str, source_text: str, allowlist: set[str]) -> int:
 def is_system_meta(fact: str) -> bool:
     """True when the 'fact' is about this memory system's own machinery or the
     AI tooling itself, not the user. Such lines are DROPPED at extraction (never
-    quarantined) — they are not biography and there is nothing to review (#36)."""
+    quarantined) — they are not biography and there is nothing to review."""
     return bool(_SYSTEM_META_RE.search(fact or ""))
 
 
 def is_builder_process(fact: str) -> bool:
     """True when the 'fact' is ordinary engineering/execution chatter about
     building a project — PR/issue mechanics, code review/CI status,
-    implementation minutiae, or transient UI styling/layout detail (#66). Such
+    implementation minutiae, or transient UI styling/layout detail. Such
     lines are DROPPED at extraction (never quarantined), same as
     `is_system_meta`: they aren't biography about the user, so there is
     nothing for a human to approve. Deliberately narrow — it does not match a
@@ -457,7 +457,7 @@ def in_scope(fact: str) -> bool:
 def check(fact: str, source_text: str, allowlist: set[str]) -> list[str]:
     """The three QUARANTINE walls (grounding, temporal grounding, source-trust).
     Returns flag descriptions; empty list = clean. System/meta scope is handled
-    separately by is_system_meta, which DROPS rather than quarantines (#36)."""
+    separately by is_system_meta, which DROPS rather than quarantines."""
     flags = []
     missing = ungrounded_entities(fact, source_text, allowlist)
     if missing:

--- a/memory_service/weighting.py
+++ b/memory_service/weighting.py
@@ -70,7 +70,7 @@ def select_for_summary(con, now: float | None = None) -> tuple[list[dict], list[
     now = now or db.now()
     # origin_agent + source travel through selection so the summary prompt (and
     # the /summary response's structured provenance) can carry each fact's real
-    # recorded origin — #110: coarse provenance, never a guessed speaker.
+    # recorded origin — coarse provenance, never a guessed speaker.
     rows = [dict(r) for r in con.execute(
         "SELECT id, content, importance, event_date, created_at, content_hash, "
         "embedding, origin_agent, source FROM facts "
@@ -91,7 +91,7 @@ def select_for_summary(con, now: float | None = None) -> tuple[list[dict], list[
     # Settle the durable pool BEFORE choosing the active one, so the active pool
     # competes over everything durable did not actually take.
     #
-    # Issue #55: this used to exclude all 250 over-selected CANDIDATES from the
+    # This used to exclude all 250 over-selected CANDIDATES from the
     # active pool while folding only 200 of them back, so the ~50 the margin
     # trimmed landed in NEITHER pool — a silent hole running from ~200 valid
     # facts to ~550, a range a mature ledger reaches quickly. The margin exists

--- a/scripts/backfill_importance.py
+++ b/scripts/backfill_importance.py
@@ -3,7 +3,7 @@
 Two populations land here: facts that predate extraction-time scoring (an
 imported legacy ledger) and — the reason this matters now — the several hundred facts the
 miner stored with NULL importance while it was silently dropping the
-importance= tag (#69). Both are invisible to summary selection in the same way:
+importance= tag. Both are invisible to summary selection in the same way:
 weighting reads a NULL as a neutral 5, so a genuinely important recent fact
 loses its profile slot to older facts carrying explicit high scores.
 
@@ -57,7 +57,7 @@ def parse_scores(out: str) -> dict[int, int]:
         m = _SCORE_RE.match(line)
         if m:
             # Cap at 9: importance 10 is owner-only PERMANENT — a batch scoring
-            # pass must never mint permanence (mirrors the miner's cap, #69).
+            # pass must never mint permanence (mirrors the miner's cap).
             scores[int(m.group(1))] = min(9, max(1, int(m.group(2))))
     return scores
 

--- a/tests/test_access_log.py
+++ b/tests/test_access_log.py
@@ -16,7 +16,7 @@ from memory_service.api import create_app
 
 
 def _client(settings):
-    # Owner-authenticated: /v1/search is gated (#125) and these tests
+    # Owner-authenticated: /v1/search is gated and these tests
     # exercise search recording, which is an owner action anyway.
     app = create_app(settings)
     return TestClient(app, base_url="http://127.0.0.1",

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -1,4 +1,4 @@
-"""The owner admin token/session for exact-row endpoints (#46 v2/v3/v4).
+"""The owner admin token/session for exact-row endpoints (admin-gate v2/v3/v4).
 
 v2 gated `GET /v1/facts` / `GET /v1/review` (and every verb on one existing
 fact by id) behind an admin token required even on loopback — but embedded
@@ -43,7 +43,7 @@ def _client(app, token=None, base_url="http://127.0.0.1"):
     return TestClient(app, base_url=base_url, headers=headers)
 
 
-# #51 slice 1: the everyday browser login is now a durable PASSWORD, not the
+# Since the password-login slice: the everyday browser login is now a durable PASSWORD, not the
 # admin token. The admin token is the out-of-band RECOVERY SECRET that gates
 # first-run enrollment/reset. These helpers set a password once (recovery-gated)
 # so the login-flow tests below can then log in with it.
@@ -65,7 +65,7 @@ def _enroll(app, password=PASSWORD):
 @pytest.mark.parametrize("method,path,kw", [
     ("get", "/v1/facts", {}),
     ("get", "/v1/review", {}),
-    # #125: verbatim transcript search, job reads (a consolidate job's
+    # Transcript gating: verbatim transcript search, job reads (a consolidate job's
     # result embeds fact rows), and the consolidate trigger are all
     # exact-row surfaces too.
     ("post", "/v1/search", {"json": {"query": "x"}}),
@@ -107,9 +107,9 @@ def test_mutate_by_id_endpoints_require_the_token_too(tmp_path):
     assert stranger.post(f"/v1/facts/{fid}/approve").status_code == 401
     assert stranger.post(f"/v1/facts/{fid}/dismiss").status_code == 401
     assert stranger.delete(f"/v1/facts/{fid}").status_code == 401
-    assert stranger.post("/v1/review/dismiss-all").status_code == 401  # (#66)
+    assert stranger.post("/v1/review/dismiss-all").status_code == 401  #
     assert stranger.post("/v1/facts/quarantine",
-                         json={"ids": [fid], "reason": "x"}).status_code == 401  # (#72)
+                         json={"ids": [fid], "reason": "x"}).status_code == 401  #
 
     # the owner, with the right token, can do all of it
     assert owner.patch(f"/v1/facts/{fid}", json={"confidence": "low"}).status_code == 200
@@ -127,7 +127,7 @@ def test_create_and_general_endpoints_stay_open_on_loopback(tmp_path, fake_llm):
     assert c.get("/v1/health").status_code == 200
     assert c.post("/v1/facts", json={"content": "Alex bakes sourdough weekly."}).status_code == 200
     assert c.post("/v1/recall", json={"query": "sourdough"}).status_code == 200
-    # /v1/search moved to the gated list under #125 — recall stays the
+    # /v1/search moved to the gated list with transcript gating — recall stays the
     # open chat-loop surface; search returns verbatim transcripts.
     assert c.get("/v1/summary").status_code == 200
 
@@ -135,7 +135,7 @@ def test_create_and_general_endpoints_stay_open_on_loopback(tmp_path, fake_llm):
 def test_attachment_routes_require_the_owner_credential(tmp_path):
     """Attachments expose exact fact rows, the source message body and up to
     4000 chars of document text, plus a hard delete — so they need the owner
-    credential on loopback exactly like /v1/facts (#53).
+    credential on loopback exactly like /v1/facts.
 
     This closes a real bypass: a sandboxed process sharing 127.0.0.1 could read
     ledger content through /v1/attachments/{id}/preview while /v1/facts
@@ -161,7 +161,7 @@ def test_attachment_routes_require_the_owner_credential(tmp_path):
 
 def test_open_recall_projects_only_contract_fields(tmp_path, fake_llm):
     """/v1/recall is open by design — every chat round calls it — so WHAT IT
-    PROJECTS is the security boundary (#56). It must return only the fields
+    PROJECTS is the security boundary. It must return only the fields
     docs/API.md promises, never the whole ledger row: content_hash,
     conversation_id, source_message_id and the quarantine bookkeeping are
     internals, and handing them to any loopback caller made the gate on
@@ -185,7 +185,7 @@ def test_open_recall_projects_only_contract_fields(tmp_path, fake_llm):
 
 def test_recall_limit_is_bounded_against_whole_ledger_export(tmp_path, fake_llm):
     """An unbounded top-N over an empty query is an export primitive, not a
-    recall (#56): 500 was enough to dump a ledger in one unauthenticated call."""
+    recall: 500 was enough to dump a ledger in one unauthenticated call."""
     app = _app(tmp_path)
     c = _client(app, token=None)
     assert c.post("/v1/recall", json={"query": "", "limit": 500}).status_code == 422
@@ -205,7 +205,7 @@ def test_unconfigured_token_is_random_and_differs_per_process(tmp_path):
     assert len(app1.state.admin_token) >= 32
 
 
-# ── #46 v3: GET / must never hand a credential to an unauthenticated caller ─
+# ── admin-gate v3: GET / must never hand a credential to an unauthenticated caller ─
 def test_unauthenticated_root_serves_locked_page_with_no_credential(tmp_path):
     app = _app(tmp_path)
     c = _client(app, token=None)
@@ -251,7 +251,7 @@ def test_login_with_wrong_password_is_refused_and_sets_no_cookie(tmp_path):
 
 
 def test_admin_token_is_not_accepted_as_the_everyday_password(tmp_path):
-    """The recovery secret must NOT double as the everyday login (#51): even
+    """The recovery secret must NOT double as the everyday login: even
     the correct admin token, submitted to /login as a password, is refused."""
     app = _app(tmp_path)
     _enroll(app)
@@ -293,7 +293,7 @@ def test_locked_page_never_contains_the_recovery_secret_even_as_a_hint(tmp_path)
     assert "a-very-specific-owner-value" not in r.text
 
 
-# ── #46 v4: the cookie is an opaque session id, NOT the bearer token ────────
+# ── admin-gate v4: the cookie is an opaque session id, NOT the bearer token ────────
 def test_session_cookie_value_is_not_the_bearer_token(tmp_path):
     app = _app(tmp_path, auth_token="a-very-specific-owner-value")
     _enroll(app)

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -8,7 +8,7 @@ from memory_service.api import create_app
 
 @pytest.fixture
 def client(settings, fake_llm):
-    # #46 v2: GET /v1/facts, GET /v1/review, and the by-id verbs now require
+    # Admin-gate v2: GET /v1/facts, GET /v1/review, and the by-id verbs now require
     # the owner admin token even on loopback — carry it as a default header
     # so the rest of this contract suite is unaffected by the tightening.
     app = create_app(settings)
@@ -69,7 +69,7 @@ def test_approve_dismiss_delete_flow(client):
 
 
 def test_dismiss_all_review_over_http(client):
-    # Bulk twin of /facts/{id}/dismiss (#66): clears the whole queue in one
+    # Bulk twin of /facts/{id}/dismiss: clears the whole queue in one
     # call, non-destructively — nothing here bypasses the admin-token gate.
     ids = [client.post("/v1/facts", json={
         "content": f"Alex has a stray fact #{i}.", "origin_agent": "mcp:x"
@@ -91,7 +91,7 @@ def test_dismiss_all_review_over_http(client):
 
 
 def test_quarantine_accepted_facts_over_http(client):
-    # #72: the third treatment for a fact already accepted as canon — neither
+    # The third treatment for a fact already accepted as canon — neither
     # DELETE (destructive) nor supersede (asserts a replacement that doesn't
     # exist). Batch, with a required reason, skipping rather than failing.
     ids = [client.post("/v1/facts", json={
@@ -100,14 +100,14 @@ def test_quarantine_accepted_facts_over_http(client):
     assert client.get("/v1/review").json()["facts"] == []   # all canon, no queue
 
     r = client.post("/v1/facts/quarantine",
-                    json={"ids": ids, "reason": "malformed (#69 era)"})
+                    json={"ids": ids, "reason": "malformed (early-miner era)"})
     assert r.status_code == 200
     assert r.json() == {"quarantined": ids, "skipped": []}
 
     # Out of canon, into the queue, reason recorded — and nothing deleted.
     queued = client.get("/v1/review").json()["facts"]
     assert {f["id"] for f in queued} == set(ids)
-    assert all(f["quarantine_reason"] == "malformed (#69 era)" for f in queued)
+    assert all(f["quarantine_reason"] == "malformed (early-miner era)" for f in queued)
     assert client.post("/v1/recall", json={"query": "malformed"}).json()["facts"] == []
 
     # Re-run is a no-op; unknown ids skip rather than 404 the whole batch.
@@ -211,7 +211,7 @@ def test_recall_and_summary_endpoints(client, fake_llm):
     assert status["status"] == "ok"
     s = client.get("/v1/summary").json()
     assert s["summary"] == "## Goals\n- triathlon" and s["source_fact_ids"]
-    # #110: structured per-fact provenance, additive to contract 1.0 — a
+    # Structured per-fact provenance, additive to contract 1.0 — a
     # client checks THIS for attribution, never the free-form prose.
     assert s["provenance"] == [
         {"id": s["source_fact_ids"][0], "origin_agent": "user",

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -131,7 +131,7 @@ def test_browse_download_and_human_delete(settings):
     """The Files surface: list with conversation context, download the exact
     bytes, and the danger-zone delete — row, FTS entry, and (unshared) bytes."""
     app = create_app(settings)
-    # the attachment routes are owner-gated (#53): they expose exact fact
+    # the attachment routes are owner-gated: they expose exact fact
     # rows, message bodies and document text, so they need a credential
     # even on loopback — same rule as /v1/facts and /v1/review.
     auth = {"Authorization": f"Bearer {app.state.admin_token}"}
@@ -164,7 +164,7 @@ def test_preview_carries_content_and_provenance(settings, fake_llm):
     with, and the ledger facts mined from that conversation — no bare ids."""
     from memory_service import ledger
     app = create_app(settings)
-    # the attachment routes are owner-gated (#53): they expose exact fact
+    # the attachment routes are owner-gated: they expose exact fact
     # rows, message bodies and document text, so they need a credential
     # even on loopback — same rule as /v1/facts and /v1/review.
     auth = {"Authorization": f"Bearer {app.state.admin_token}"}
@@ -201,7 +201,7 @@ def test_delete_keeps_shared_bytes(settings):
     """Bytes are content-addressed: deleting one row must not take the file
     out from under another message carrying the same document."""
     app = create_app(settings)
-    # the attachment routes are owner-gated (#53): they expose exact fact
+    # the attachment routes are owner-gated: they expose exact fact
     # rows, message bodies and document text, so they need a credential
     # even on loopback — same rule as /v1/facts and /v1/review.
     auth = {"Authorization": f"Bearer {app.state.admin_token}"}

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -45,7 +45,7 @@ def test_read_limits_are_bounded(settings):
     app = create_app(settings)
     c = TestClient(app, base_url="http://127.0.0.1")
     assert c.post("/v1/recall", json={"query": "x", "limit": 99999}).status_code == 422
-    # #46 v2 / #125: /v1/facts and /v1/search require the owner admin token
+    # Admin gate + transcript gating: /v1/facts and /v1/search require the owner admin token
     # even on loopback — send it so these assertions still test the LIMIT
     # bound, not the (separately tested) auth gate.
     auth = {"Authorization": f"Bearer {app.state.admin_token}"}
@@ -55,9 +55,9 @@ def test_read_limits_are_bounded(settings):
 
 
 def test_post_facts_quarantines_model_origin(settings):
-    """#49: a model-origin write over POST /v1/facts must land in review, not
+    """A model-origin write over POST /v1/facts must land in review, not
     canon — the HTTP route inherits the write gate, and this pins it so the
-    boundary can't silently regress (the live-service symptom that opened #49).
+    boundary can't silently regress (the live-service symptom that exposed the hole).
     A plain 'user' write, and an mcp:* origin that names a trusted source_app,
     are both exercised to prove the gate keys on the write, not a claimed app."""
     client = TestClient(create_app(settings), base_url="http://127.0.0.1")
@@ -95,12 +95,12 @@ def test_memory_port_env_reaches_the_app(monkeypatch):
     assert load_settings().port == 8916
 
 
-# ---------- trusted hosts: the browser surface over a tailnet (#83) ----------
+# ---------- trusted hosts: the browser surface over a tailnet ----------
 #
 # WHY this exists: a browser cannot attach an Authorization header to a
 # navigation, so the token rule above made the owner's own phone — over the
 # one sanctioned non-loopback path — unable to reach even the lock screen,
-# leaving #51's password gate unreachable from the device it exists for.
+# leaving the owner password gate unreachable from the device it exists for.
 # These tests pin the narrow widening: the LOGIN surface and an
 # already-authenticated session, never anonymous access to fact data.
 

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -1,4 +1,4 @@
-"""Image captions at distill time (#107): photos stop being invisible to memory.
+"""Image captions at distill time: photos stop being invisible to memory.
 
 All keyless: the vision call is injected or monkeypatched, never real.
 """
@@ -110,7 +110,7 @@ def test_one_bad_image_does_not_stop_the_rest(con, settings):
 
 
 def test_distill_mines_facts_from_the_caption(con, settings, fake_llm, monkeypatch):
-    """The end-to-end point of #107: photo content becomes ledger content."""
+    """The end-to-end point of photo captions: photo content becomes ledger content."""
     conv = _ingest_photo_chat(con, settings)
     monkeypatch.setattr(
         "memory_service.captions.llm.utility_vision",
@@ -153,7 +153,7 @@ def test_caption_prompt_carries_no_animal_or_species_examples():
 
 
 def test_caption_prompt_forbids_species_and_brand_guessing():
-    """The grounding rules are the point of #107 — pin them."""
+    """The grounding rules are the point of the caption work — pin them."""
     for required in ("literally visible", "Do NOT identify", "species",
                      "generic terms"):
         assert required in captions._PROMPT

--- a/tests/test_integrity_cache.py
+++ b/tests/test_integrity_cache.py
@@ -1,4 +1,4 @@
-"""The integrity verdict answers from cache, not from a live scan (#79).
+"""The integrity verdict answers from cache, not from a live scan.
 
 `PRAGMA quick_check` scans the whole database file; running it inside
 /v1/health put that scan on the chat client's round-critical path. These

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -48,7 +48,7 @@ def test_4_untrusted_origin_always_quarantined(con, settings):
     assert not ledger.add_fact(con, "Alex runs marathons.", settings,
                                origin_agent="claude",
                                source_app="multi-model-chat")["quarantined"]
-    # #49: an mcp:* origin can NEVER launder itself into canon by declaring a
+    # An mcp:* origin can NEVER launder itself into canon by declaring a
     # trusted source_app — the write is gated, not the writer.
     assert ledger.add_fact(con, "Alex is secretly a spy.", settings,
                            origin_agent="mcp:claude-code",
@@ -72,7 +72,7 @@ def test_6_summary_claims_trace_to_source_facts(con, settings, fake_llm):
     assert s["summary"] == "## Preferences\n- woodworking"
     assert s["source_fact_ids"] == [a["id"]]
     assert s["generated_at"] is not None
-    # #110: each traced fact's RAW origin is exposed too, mechanically derived
+    # Each traced fact's RAW origin is exposed too, mechanically derived
     # (never a guessed speaker) — see tests/test_summary_provenance.py.
     assert s["provenance"] == [
         {"id": a["id"], "origin_agent": "user", "source": "user", "tag": "direct"}]

--- a/tests/test_ledger_recall.py
+++ b/tests/test_ledger_recall.py
@@ -11,7 +11,7 @@ def test_add_rejects_trivial_content(con, settings):
 
 
 def test_parse_id_query_only_fires_on_the_hash_form():
-    # `#` is what disambiguates (#74): a bare number is a legitimate thing to
+    # `#` is what disambiguates: a bare number is a legitimate thing to
     # search the TEXT for, so reading it as an id would break content search.
     assert ledger.parse_id_query("#12") == [12]
     assert ledger.parse_id_query(" #12, 34  56 ") == [12, 34, 56]
@@ -22,7 +22,7 @@ def test_parse_id_query_only_fires_on_the_hash_form():
 
 
 def test_ledger_id_query_looks_up_ids_not_text(con, settings):
-    # #74: the ledger search matches content, so "1990" finds facts whose TEXT
+    # The ledger search matches content, so "1990" finds facts whose TEXT
     # says 1990 — not fact id 1990. `#` switches it to an id lookup, so a list
     # of ids handed over by a diagnostic can be acted on directly.
     decoy = ledger.add_fact(con, "Alex bought the house in 1990.", settings)
@@ -42,7 +42,7 @@ def test_ledger_id_query_looks_up_ids_not_text(con, settings):
 
 def test_ledger_id_query_is_never_trimmed_by_the_page_size(con, settings):
     # An explicit id list asks for exactly those rows; trimming it to the page
-    # size would read as "those ids don't exist" — a silent wrong answer (#74).
+    # size would read as "those ids don't exist" — a silent wrong answer.
     ids = [ledger.add_fact(con, f"Alex owns record number {i} outright.",
                            settings)["id"] for i in range(5)]
     q = "#" + ",".join(str(i) for i in ids)
@@ -71,7 +71,7 @@ def test_review_queue_and_dismiss(con, settings):
 
 
 def test_dismiss_all_clears_the_whole_queue_non_destructively(con, settings):
-    # Bulk twin of dismiss (#66) — for clearing a backlog made stale by a
+    # Bulk twin of dismiss — for clearing a backlog made stale by a
     # filtering fix in one action. Same semantics as one-at-a-time dismiss:
     # every affected fact stays quarantined and in the ledger, only leaves the
     # review queue, and each remains reversible via approve.
@@ -102,7 +102,7 @@ def test_dismiss_all_clears_the_whole_queue_non_destructively(con, settings):
 
 
 def test_quarantine_many_pulls_accepted_facts_out_of_canon(con, settings):
-    # #72: a fact accepted as canon that later turns out to be malformed had
+    # A fact accepted as canon that later turns out to be malformed had
     # no non-destructive treatment — DELETE erases it, supersede asserts a
     # replacement that a garbage row doesn't have. quarantine_many is that
     # third option, and it's a batch because the real cases are batches.
@@ -195,7 +195,7 @@ def test_importance_is_owner_correctable(con, settings):
 
 def test_facts_embed_at_write_time(con, settings, monkeypatch):
     """The recall after a save must not pay the provider round-trip: writes
-    spawn a background embed (Fixes #8); the recall-path ensure stays as the
+    spawn a background embed; the recall-path ensure stays as the
     keyless/failure safety net."""
     import time
     from memory_service import embeddings, ledger

--- a/tests/test_mcp_admin_server.py
+++ b/tests/test_mcp_admin_server.py
@@ -1,4 +1,4 @@
-"""The admin MCP adapter (#46) — read-only, authenticated, ids + status exact.
+"""The admin MCP adapter — read-only, authenticated, ids + status exact.
 
 Talks HTTP to the same FastAPI app as the rest of the suite (via Starlette's
 in-process TestClient — no real socket, no network, keyless), never opens the
@@ -17,7 +17,7 @@ from memory_service.api import create_app
 @pytest.fixture
 def wired(settings, fake_llm, monkeypatch):
     """Point the admin client at an in-process app instead of a real socket,
-    already carrying the SAME admin token the app itself minted (#46 v2:
+    already carrying the SAME admin token the app itself minted (admin-gate v2:
     GET /v1/facts and GET /v1/review now require it even on loopback) — the
     normal operating condition once a session is properly registered."""
     app = create_app(settings)
@@ -84,7 +84,7 @@ def test_no_mutate_tool_is_exposed():
 
 
 def test_unreachable_service_degrades_to_a_clear_error(monkeypatch):
-    """A sandboxed session with no route to the live service (the #46 incident)
+    """A sandboxed session with no route to the live service (the admin-gate incident)
     gets a readable error, not a crash or a raw traceback."""
     monkeypatch.setenv("MEMORY_AUTH_TOKEN", "s3cret")
     monkeypatch.setenv("MEMORY_API_URL", "http://127.0.0.1:1/v1")  # nothing listens

--- a/tests/test_mcp_save_memory.py
+++ b/tests/test_mcp_save_memory.py
@@ -1,4 +1,4 @@
-"""Regression coverage for #66 on the direct MCP write path.
+"""Regression coverage for the engineering-chatter wall on the direct MCP write path.
 
 `save_memory` (mcp_server.py) is the loudest leak the issue names: an
 `mcp:*` origin is always quarantined by provenance regardless of content, so
@@ -47,7 +47,7 @@ def test_save_memory_drops_builder_process_noise_without_quarantining(con):
 def test_save_memory_still_quarantines_a_durable_outcome_or_preference(con):
     # Process/mechanics content is dropped; a real preference or project
     # outcome from the SAME untrusted origin still reaches review — the
-    # existing mcp:* provenance gate (#4) is untouched by this fix.
+    # existing mcp:* provenance gate is untouched by this fix.
     result = mcp_server.save_memory(
         "Alex decided to leave Initech and go freelance full-time.")
     assert "held for the user's review" in result

--- a/tests/test_meta_conversation.py
+++ b/tests/test_meta_conversation.py
@@ -1,5 +1,5 @@
-"""Regression tests for #36 — extraction walls flooding review on meta/system
-conversations, and overlapping distills multiplying facts — plus #66, the
+"""Regression tests for the meta-conversation flood — extraction walls flooding review on meta/system
+conversations, and overlapping distills multiplying facts — plus the
 sibling flood from ordinary builder-process chatter about ANY project.
 
 Four guarantees:
@@ -8,13 +8,13 @@ Four guarantees:
    genuine career fact in the same conversation is kept and not quarantined.
 2. A distill for a conversation already in flight is skipped, so overlapping
    runs cannot re-mine the same messages and multiply facts.
-3. (#66, first pass) A conversation full of PR/issue/CI mechanics and UI
+3. (First pass) A conversation full of PR/issue/CI mechanics and UI
    styling minutiae yields NO review flood either, while a durable career
    decision in the same conversation is kept and not quarantined.
-4. (#66, reopened) A conversation full of deep TECHNICAL reasoning/diagnosis —
+4. (Reopened) A conversation full of deep TECHNICAL reasoning/diagnosis —
    none of which trips the builder-process keyword regex — yields at most one
    project-thread fact and never surfaces the reasoning itself as a pending
-   (or valid) fact. This is the gap #67's regex-only fix left open: the fix is
+   (or valid) fact. This is the gap the first regex-only fix left open: the fix is
    the extraction prompt's positive two-level rule, not more keywords.
 """
 
@@ -75,7 +75,7 @@ def test_meta_lines_are_dropped_before_the_grounding_wall(con, settings, fake_ll
     assert ledger.list_facts(con, status="quarantined") == []
 
 
-# A realistic stretch of ordinary builder-process chatter (#66): PR/issue
+# A realistic stretch of ordinary builder-process chatter: PR/issue
 # mechanics, review/CI status, and transient UI styling minutiae, with one real
 # career decision dropped in the middle.
 _BUILDER_CHAT = [
@@ -200,7 +200,7 @@ def test_distill_skips_when_conversation_already_in_flight(con, settings,
                                                            sample_conversation, fake_llm):
     # Hold the per-conversation lock to simulate an in-flight distill; a second
     # distill must skip immediately and mine nothing — the guard that stops
-    # overlapping runs from multiplying facts (#36).
+    # overlapping runs from multiplying facts.
     fake_llm["response"] = "NEW importance=6: Alex works at Initech as a data engineer."
     lock = mining._conversation_lock("multi-model-chat", "chat-1")
     assert lock.acquire(blocking=False)
@@ -222,7 +222,7 @@ def test_re_mining_the_same_messages_does_not_duplicate_facts(con, settings,
     # The lock guards two runs OVERLAPPING in-process; it cannot guard a run that
     # added facts then died before advancing the watermark, so the next distill
     # re-mines the same messages. The conversation-scoped content_hash guard in
-    # add_fact collapses that re-mine instead of multiplying the fact (#36).
+    # add_fact collapses that re-mine instead of multiplying the fact.
     fake_llm["response"] = "NEW importance=6: Alex works at Initech as a data engineer."
     first = mining.distill(con, settings, "multi-model-chat", "chat-1", regenerate=False)
     assert first["added"] == 1

--- a/tests/test_mining.py
+++ b/tests/test_mining.py
@@ -22,7 +22,7 @@ def test_distill_mines_and_grounds(con, settings, sample_conversation, fake_llm)
 
 
 def test_distill_supersedes_listed_entry(con, settings, sample_conversation, fake_llm):
-    # Target is event-dated BEFORE the superseding conversation — the #120
+    # Target is event-dated BEFORE the superseding conversation — the backdating
     # guard refuses the reverse direction.
     old = ledger.add_fact(con, "Alex works at Globex.", settings,
                           event_date=1690000000.0)
@@ -32,13 +32,13 @@ def test_distill_supersedes_listed_entry(con, settings, sample_conversation, fak
 
 
 def test_supersede_reaches_beyond_recency_window(con, settings, fake_llm):
-    """#71: the candidate list the miner sees was ONLY the 250 newest valid
+    """The candidate list the miner sees was ONLY the 250 newest valid
     facts by insertion id, so a target older than that window could never be
     offered for supersession no matter how directly a new fact contradicted
     it. Push the target out of that window with 260 unrelated filler facts,
     then confirm a directly-contradicting new fact still supersedes it."""
     old = ledger.add_fact(con, "Alex works at Globex as a systems architect.",
-                          settings, event_date=1690000000.0)  # predates the chat (#120)
+                          settings, event_date=1690000000.0)  # predates the chat
     for i in range(260):  # older by content but each insert pushes `old`
         ledger.add_fact(con, f"Filler fact number {i} about something unrelated.",
                         settings)
@@ -57,7 +57,7 @@ def test_supersede_reaches_beyond_recency_window(con, settings, fake_llm):
 
 
 def test_supersede_survives_many_intervening_mined_facts(con, settings, fake_llm):
-    """#71 regression: a fact mined first, then directly contradicted by a
+    """Recency-window regression: a fact mined first, then directly contradicted by a
     fact mined much later, is still superseded — independent of how many
     other facts were inserted in between (not just a fixed-N stopgap)."""
     from memory_service import episodic
@@ -108,7 +108,7 @@ def test_unknown_conversation_raises(con, settings):
         mining.distill(con, settings, "multi-model-chat", "nope")
 
 
-# --- Dating by real-world event time (#30) --------------------------------
+# --- Dating by real-world event time --------------------------------
 # A fact defaults to the conversation timestamp, EXCEPT when the source text
 # states an explicit calendar date — then it is back-dated to that day. A
 # relative/vague phrase, or a date the model invents, is never honoured.
@@ -174,14 +174,14 @@ def test_hallucinated_date_not_grounded_is_ignored(con, settings, fake_llm):
     assert fact["event_date"] == 1700000060.0          # invented date ignored
 
 
-# --- Binding a fact to its source message before grounding (#33) ----------
-# #32 grounded the model's event= against the WHOLE mined chunk, so a date
+# --- Binding a fact to its source message before grounding ----------
+# Grounding used to read the model's event= against the WHOLE mined chunk, so a date
 # mentioned in any message could ground a fact extracted from a different one.
 # Now the extractor tags each fact with src=<N> (a [msg N] label). A VALID
 # binding is a hard prerequisite for honouring event=: grounding then reads
 # only that one message's text. If src is missing OR invalid, the proposed
 # event date is rejected outright and the fact falls back to conversation time
-# — never grounded against the latest turn — so the #30/#32 "never guess" holds.
+# — never grounded against the latest turn — so the "never guess a date" rule holds.
 
 
 def _ingest_many(con, msgs, conv_id="chat-m"):
@@ -193,7 +193,7 @@ def _ingest_many(con, msgs, conv_id="chat-m"):
 
 
 def test_date_in_other_message_is_rejected(con, settings, fake_llm):
-    # The exact #33 hole: June 30 is stated in msg 1, but the fact is bound to
+    # The exact date-borrowing hole: June 30 is stated in msg 1, but the fact is bound to
     # msg 2 (which says nothing about a date). The date must NOT ground it even
     # though it is literally present elsewhere in the chunk.
     _ingest_many(con, [
@@ -277,7 +277,7 @@ def test_grounded_event_date_helper():
 
 
 def test_invented_relative_gloss_is_held_for_review(con, settings, fake_llm):
-    """#38 end-to-end: the source states a relative schedule; the miner resolves
+    """Invented-relative-date, end to end: the source states a relative schedule; the miner resolves
     it to the wrong day and states that resolution as fact. The event_date was
     already safe (a relative phrase can never ground one), but the fact's PROSE
     asserted a schedule nobody stated — and no wall looked at prose dates, so it
@@ -309,7 +309,7 @@ def test_source_qualifier_kept_verbatim_passes_clean(con, settings, fake_llm):
     assert fact["event_date"] == 1700000060.0   # conversation time, not resolved
 
 
-# --- importance is REQUIRED: retry once, then quarantine (#69) -------------
+# --- importance is REQUIRED: retry once, then quarantine -------------
 # The miner (a smaller utility model) began dropping the importance= tag after
 # the output grammar grew event= and src= (2026-07-15). The parser used to
 # store the omission as NULL, which summary selection reads as a neutral 5 — so
@@ -386,7 +386,7 @@ def test_malformed_importance_quarantined_when_retry_also_fails(
 
 
 def test_backdated_fact_cannot_supersede_newer(con, settings, fake_llm):
-    """#120: mining old history (imported exports, late re-mines) must never
+    """Backdating guard: mining old history (imported exports, late re-mines) must never
     invalidate a newer fact. The old-dated fact still lands, event-dated to
     its conversation; only the supersession is refused."""
     from memory_service import episodic
@@ -409,7 +409,7 @@ def test_backdated_fact_cannot_supersede_newer(con, settings, fake_llm):
 
 
 def test_quarantined_fact_defers_supersession(con, settings, fake_llm):
-    """#120: an untrusted-origin mined fact is quarantined by the write gate —
+    """Backdating guard: an untrusted-origin mined fact is quarantined by the write gate —
     and a held-for-review fact must not alter canon. Its supersession is
     deferred (surfaced in the result), never auto-applied."""
     from memory_service import episodic

--- a/tests/test_password_login.py
+++ b/tests/test_password_login.py
@@ -1,4 +1,4 @@
-"""Owner-password enrollment / login / reset — #51 delivery slice 1.
+"""Owner-password enrollment / login / reset — the password-login delivery slice.
 
 The everyday admin login used to be the process's admin token: ephemeral by
 default (a fresh one every restart) and doubling as the MCP/curl bearer
@@ -15,7 +15,7 @@ restart. Slice 1 replaces it with a durable password:
   verifier ever appears in any unauthenticated response.
 - The MCP/curl Bearer path and exact-row gating are untouched.
 
-These are the slice-1 acceptance tests; #46's session mechanics live in
+These are the slice-1 acceptance tests; the admin-gate session mechanics live in
 test_admin_auth.py.
 """
 

--- a/tests/test_process_docs.py
+++ b/tests/test_process_docs.py
@@ -1,4 +1,4 @@
-"""The written process must say what we actually do (#114).
+"""The written process must say what we actually do.
 
 CONTRIBUTING.md and CLAUDE.md disagreed for months: one said work lands as
 "small complete commits", the other said it goes through a PR. The stale one
@@ -57,7 +57,7 @@ def test_claude_md_defers_rather_than_duplicating_the_process():
 
 
 def test_both_docs_agree_the_supervisor_owns_restarts():
-    """#111: a hand-start fails loudly while the old code keeps running, so
+    """Supervisor rule: a hand-start fails loudly while the old code keeps running, so
     'restart the service' has to name the supported command in both places."""
     for path in (CONTRIBUTING, CLAUDE):
         assert "launchctl kickstart" in path.read_text(), \

--- a/tests/test_recall_hot_path.py
+++ b/tests/test_recall_hot_path.py
@@ -1,4 +1,4 @@
-"""Recall hot-path mechanics (#78): same answers, less work per call.
+"""Recall hot-path mechanics: same answers, less work per call.
 
 The refactor changed WHERE the math runs (one client, one query
 normalization, one unpack per fact) and must not change a single ranking
@@ -71,7 +71,7 @@ def test_semantic_ranking_and_paraphrase_collapse_survive_the_refactor(
 def test_keyword_only_path_still_collapses_paraphrases(
         con, settings, semantic_ledger, monkeypatch):
     """No query vector (keyless): facts still carry embeddings, and the
-    paraphrase collapse must keep using them — the #78 fallback."""
+    paraphrase collapse must keep using them — the keyless fallback."""
     monkeypatch.setattr(embeddings, "embed_query", lambda q, s: None)
     got = recall.recall(con, settings, query="chess club", limit=5)
     contents = [f["content"] for f in got]

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -122,7 +122,7 @@ def test_tree_scan_is_clean():
     assert rc == 0, f"a secret or identifier is in the committed tree:\n{out}"
 
 
-# ── a staged decorator line must never read as an email (#46 regression) ────
+# ── a staged decorator line must never read as an email ────
 def test_staged_decorator_line_is_not_flagged_as_email(tmp_path):
     """git diff prefixes every added line with a bare '+'. A module-level
     decorator like '@mcp.tool()' or '@pytest.fixture' sits flush against that
@@ -151,7 +151,7 @@ def test_files_path_prefix_is_not_scanned(tmp_path):
     """--files must scan file CONTENT only. A clean file that merely LIVES under
     a real-looking home path (/Users/<name>/…, /home/runner/… in CI) must pass —
     the caller's path is not the repo's content. A sibling mirror of this
-    scanner shipped with a path-prefix bug (#96) that failed every scan on a
+    scanner shipped with a path-prefix bug that failed every scan on a
     real machine; this pins membro against ever growing the same one."""
     home = tmp_path / "Users" / "realperson"
     home.mkdir(parents=True)
@@ -161,7 +161,7 @@ def test_files_path_prefix_is_not_scanned(tmp_path):
     assert rc == 0, f"file path leaked into scanned text:\n{out}"
 
 
-# ── the gate can detect, not just pass (#54) ─────────────────────────────────
+# ── the gate can detect, not just pass ─────────────────────────────────
 #
 # `test_tree_scan_is_clean` above asserts a clean tree scans clean — which is
 # EXACTLY what a --tree mode scanning zero bytes would also produce. Every other
@@ -229,7 +229,7 @@ def test_the_bare_invocation_trap_is_real_and_pinned(tmp_path):
 
 
 def test_the_documented_history_scan_reads_a_real_file(tmp_path):
-    """#54's second half: `--files` skips anything that isn't a regular file, so
+    """The history-scan doc fix, second half: `--files` skips anything that isn't a regular file, so
     PIPING a git log into it silently scans nothing. RELEASING.md now says to
     write the log to a file first — this proves that instruction works and that
     the piped form it warns against would not."""

--- a/tests/test_summary_budget.py
+++ b/tests/test_summary_budget.py
@@ -69,7 +69,7 @@ def test_emergent_topics_prompt_keeps_the_spine(con, settings, fake_llm):
     """The model names the middle sections; the stable→volatile spine
     (Identity … Recent Changes) stays fixed — that ordering is load-bearing.
 
-    Graduated from an experiment to the only behaviour on 2026-07-26 (#13), so
+    Graduated from an experiment to the only behaviour on 2026-07-26, so
     this is no longer "the default" — there is nothing else to be."""
     _seed(con, settings)
     fake_llm["response"] = "## Identity\n- x"

--- a/tests/test_summary_freshness.py
+++ b/tests/test_summary_freshness.py
@@ -2,9 +2,9 @@
 resolve temporally conflicting status facts, and must never present a stale
 profile as if it were timeless.
 
-#22 — the summary prompt carries each entry's event_date (date-only) and an
+Prompt side — the summary prompt carries each entry's event_date (date-only) and an
 explicit latest-wins rule for conflicting current-state / active-thread status.
-#27 — the MCP memory_summary tool stamps its output with generated_at and warns
+Tool side — the MCP memory_summary tool stamps its output with generated_at and warns
 that time-sensitive status should be verified with recall.
 """
 
@@ -41,7 +41,7 @@ def test_prompt_carries_latest_wins_rule(con, settings, fake_llm):
 
 def test_mcp_summary_is_stamped_with_generated_at():
     """The MCP tool prepends a readable generated_at stamp and a verify-with-
-    recall warning ahead of the profile prose (#27)."""
+    recall warning ahead of the profile prose."""
     generated = datetime.datetime(2026, 5, 28, 10, 0, 0,
                                   tzinfo=datetime.timezone.utc).timestamp()
     out = _format_summary({"summary": "## Identity\n- profile body",

--- a/tests/test_summary_provenance.py
+++ b/tests/test_summary_provenance.py
@@ -1,4 +1,4 @@
-"""#110 — coarse fact provenance survives selection and reaches the summary,
+"""Coarse fact provenance survives selection and reaches the summary,
 both as a mechanically-derived prompt tag and as structured `/summary`
 metadata. Deliberately NOT true speaker attribution: a mined fact spans
 possibly several turns and has no single recorded speaker, so the one thing
@@ -13,7 +13,7 @@ from memory_service import ledger, mining, summary, weighting
 def test_selection_carries_origin_agent_and_source(con, settings):
     """weighting.select_for_summary must expose the raw columns, not just
     content/importance/event_date — the prompt renderer and the /summary
-    response both need them (#110)."""
+    response both need them."""
     direct = ledger.add_fact(con, "Alex prefers dark roast coffee.", settings)
     curated = ledger.add_fact(con, "Alex's assistant noted a new hobby.",
                               settings, origin_agent="gpt-5",
@@ -98,7 +98,7 @@ def test_participant_curated_fact_keeps_raw_origin_no_flattening(
 
 def test_summary_response_exposes_structured_provenance(con, settings, fake_llm):
     """Structured metadata (not prose) is the mechanically-checkable surface a
-    downstream consumer should actually rely on for attribution (#110)."""
+    downstream consumer should actually rely on for attribution."""
     direct = ledger.add_fact(con, "Alex prefers dark roast coffee.", settings)
     fake_llm["response"] = "## Preferences\n- coffee"
     summary.regenerate(con, settings)

--- a/tests/test_summary_weighting.py
+++ b/tests/test_summary_weighting.py
@@ -93,7 +93,7 @@ def test_paraphrase_collapse_in_selection(con):
 
 def test_miner_parses_importance(con, settings, fake_llm, sample_conversation):
     # A scored fact lands valid with its score; an UNSCORED fact that the miner
-    # fails to score even on the corrective retry (#69) is quarantined for
+    # fails to score even on the corrective retry is quarantined for
     # review, so weighting never has to read its missing score as a neutral 5.
     fake_llm["queue"] = [
         "NEW importance=8: Alex accepted a new role at Initech.\n"
@@ -203,7 +203,7 @@ def test_pinned_facts_always_reach_the_profile(con, settings):
 
 
 def test_no_card_falls_between_the_two_pools(con, settings):
-    """#55: the durable pool over-selects DURABLE_N × POOL_MARGIN (250)
+    """The durable pool over-selects DURABLE_N × POOL_MARGIN (250)
     candidates so paraphrase collapse can't starve it, then trims back to 200.
     The ~50 the margin trims MUST fall through to the active pool.
 

--- a/tests/test_supervisor_plist.py
+++ b/tests/test_supervisor_plist.py
@@ -1,4 +1,4 @@
-"""The launchd supervisor (#111) is a placeholder template rendered by
+"""The launchd supervisor is a placeholder template rendered by
 ops/install-supervisor.sh at install time. These tests pin the things that make
 it safe and correct without needing macOS or launchd:
 
@@ -9,7 +9,7 @@ it safe and correct without needing macOS or launchd:
      self-restarting, run-at-load agent pointing at start.sh.
   3. It supervises MEMBRO, on Membro's port — a copy-paste of a sibling service's agent
      with its label or port left behind would fight that sibling for its port and
-     leave memory unsupervised, which is the exact failure #111 exists to end.
+     leave memory unsupervised, which is the exact failure the supervisor exists to end.
 
 Keyless and cross-platform: plistlib is stdlib, so this runs in CI on Linux
 where `plutil` does not exist.
@@ -59,7 +59,7 @@ def test_rendered_plist_is_valid_and_fully_substituted():
 
 
 def test_agent_restarts_itself_and_starts_at_login():
-    """The whole point of #111: a crash or a stray kill must not leave memory
+    """The whole point of the supervisor: a crash or a stray kill must not leave memory
     dark. KeepAlive restarts it; RunAtLoad brings it back after a reboot;
     ThrottleInterval stops a hard boot failure spinning."""
     p = plistlib.loads(_render().encode())

--- a/tests/test_tailscale_serve.py
+++ b/tests/test_tailscale_serve.py
@@ -1,5 +1,5 @@
 """scripts/tailscale-serve.sh — the opt-in, tailnet-only remote-access route
-(#51 slice 2). Keyless and hermetic: no real Tailscale install is required or
+. Keyless and hermetic: no real Tailscale install is required or
 assumed. A fake `tailscale` CLI is planted on PATH so these tests exercise the
 script's own logic (locate → check signed-in → serve → verify → report),
 never a real network.
@@ -83,7 +83,7 @@ def test_script_exists():
 #    invoked the REAL binary. What makes this test file safe is that no bundle
 #    path is ever USED implicitly — mentioning one in help text is fine and
 #    now necessary, since on macOS that is exactly where the working CLI lives
-#    (#87). Same shape as the funnel test below: comments and warnings may
+#. Same shape as the funnel test below: comments and warnings may
 #    name it; nothing may resolve to it on its own.)
 def test_cli_is_never_resolved_implicitly_to_an_app_bundle():
     text = SCRIPT.read_text()
@@ -187,7 +187,7 @@ def test_defaults_are_port_8443_onto_local_8901(tmp_path):
     calls = log.read_text()
     assert "127.0.0.1:8901" in calls
     assert "--https=8443" in calls
-    # no path-mount flag layout is attempted at all any more (#82 review):
+    # no path-mount flag layout is attempted at all any more (the serve-flag review):
     # serving a whole origin on a port needs none, so the two-attempt
     # fallback and its version ambiguity are gone with it
     assert "--set-path" not in calls
@@ -239,12 +239,12 @@ def test_start_sh_never_blocks_on_tailscale_failure():
     )
 
 
-# ── an installed-but-off-PATH CLI is usable when named EXPLICITLY (#87) ──────
+# ── an installed-but-off-PATH CLI is usable when named EXPLICITLY ──────
 def test_memory_tailscale_bin_is_honoured_when_path_has_no_cli(tmp_path):
     """The macOS normal case: Tailscale is installed and working, its CLI just
     isn't on PATH. Naming it explicitly must work — while an EMPTY PATH with
     no env var still skips, so nothing is ever guessed (that guess is what
-    executed a developer's real CLI during #82's test run)."""
+    executed a developer's real CLI during the serve-flag review's test run)."""
     fake_dir = tmp_path / "elsewhere"
     fake_dir.mkdir()
     _make_fake_tailscale(fake_dir, signed_in=True, serve_ok=True,
@@ -262,7 +262,7 @@ def test_no_cli_and_no_env_var_still_skips_without_guessing(tmp_path):
     assert rc == 0
     assert "SKIPPED" in err
     # the skip message points at the real fix, and no longer claims the
-    # app-bundle CLI cannot serve (#87)
+    # app-bundle CLI cannot serve
     assert "MEMORY_TAILSCALE_BIN" in err
     assert "does not support" not in err
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -75,7 +75,7 @@ def test_math_page_served(settings):
     from memory_service.api import create_app
     app = create_app(settings)
     # /math itself carries no ledger content (geometry only) and needs no
-    # auth; the admin page it's linked FROM does (#46 v3), so authenticate
+    # auth; the admin page it's linked FROM does (admin-gate v3), so authenticate
     # for that one request.
     with TestClient(app, base_url="http://127.0.0.1") as client:
         r = client.get("/math")

--- a/tests/test_walls.py
+++ b/tests/test_walls.py
@@ -35,7 +35,7 @@ def test_dossier_framing_flagged():
 
 
 def test_system_meta_is_a_drop_signal_not_a_quarantine_flag():
-    # #36: system self-reference is now a DROP signal (is_system_meta), and no
+    # System self-reference is now a DROP signal (is_system_meta), and no
     # longer a quarantine flag returned by check().
     meta = "The memory ledger quarantined the fact after the grounding wall fired."
     assert walls.is_system_meta(meta)
@@ -49,7 +49,7 @@ def test_scope_wall_passes_user_biography():
 
 
 def test_career_fact_with_product_or_deploy_is_not_dropped():
-    # #36: the narrowed filter targets system MECHANICS, not generic verbs or
+    # The narrowed filter targets system MECHANICS, not generic verbs or
     # product names — a real career/project fact must survive extraction.
     for fact in [
         "Alex deployed the payments service to production on Friday.",
@@ -61,7 +61,7 @@ def test_career_fact_with_product_or_deploy_is_not_dropped():
 
 
 def test_builder_process_noise_is_a_drop_signal():
-    # #66: engineering/execution chatter about building ANY project — PR/issue
+    # Engineering/execution chatter about building ANY project — PR/issue
     # mechanics, review/CI status, implementation minutiae, transient UI
     # styling — is a DROP signal, same discipline as is_system_meta.
     for fact in [
@@ -92,19 +92,19 @@ def test_acronyms_not_treated_as_proper_nouns():
     assert walls.proper_nouns("The API and SDK and MCP", set()) == []
 
 
-# ── temporal grounding (#38) ─────────────────────────────────────────────────
+# ── temporal grounding ─────────────────────────────────────────────────
 # The grounding wall above checks proper NOUNS, so it never saw a date. A fact
 # could therefore assert a schedule nobody stated — "Saturday (tomorrow from the
 # conversation date)" — and pass every wall at high confidence. The weekday was
 # real; the interval was invented. Broadly-correct biography, wrong near-term
-# planning, which is the recurring trust damage #38 describes.
+# planning, which is the recurring relative-date trust damage.
 
 SCHEDULE = ("Alex: the appointment is on Saturday, roughly nine days away, "
             "so I'll be back before the Initech offsite.")
 
 
 def test_invented_relative_gloss_is_quarantined():
-    # The #38 case exactly: the nearest Saturday is not the intended one, and
+    # The canonical case: the nearest Saturday is not the intended one, and
     # the miner resolved it anyway.
     flags = walls.check(
         "Alex's appointment is Saturday (tomorrow from the conversation date).",


### PR DESCRIPTION
Fixes #8.

The census (git blame against the initial-release commit `3ece36b`) found 220 pre-publication tracker citations against 110 legitimate post-publication ones. A reader who follows one of the old numbers lands on an unrelated public issue - #46 alone collides with a real issue while naming a four-version private design history.

**The pass, per line:**
- 110 parenthetical citations whose sentence already carried the meaning: dropped.
- 99 citations doing real work: rewritten so the design event is named in words. The recurring families got stable names used consistently - the admin-gate v2/v3/v4 lineage, the password-login slice, the meta-conversation flood, the engineering-chatter wall (both passes), the never-guess-dates rule, the date-borrowing hole, the backdating guard, the recency-window blind spot, the supervisor, coarse provenance, transcript gating.
- 11 deliberately untouched: fixture strings the walls and parsers actually process (`"PR #143"`, `parse_id_query("#12")`), the wall's own pattern documentation quoting them, and ledger.py's numbered module invariants. None are tracker citations. Two fixture reason-strings reading as tracker history ("#69 era") were neutralised.
- Post-publication references to real public issues are all kept, verified per line by blame.

Comments, docstrings and two fixture strings only - no behaviour. Full suite: 467 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM)_