### PR TITLE
Passkey registers as "membro owner", not a bare "owner"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- Your passkey now says whose it is (#68). The system account
+  picker lists every localhost app's passkey in one sheet, and
+  membro's row used to read as a bare "owner". New enrolments
+  register as "membro owner". An existing passkey keeps its old
+  label until re-enrolled: remove it in the admin Passkeys panel,
+  then enrol again.
+
 - Transcript search survives an emptied search index (#38). An
   empty-but-valid FTS index answers every query with zero rows without
   raising, so drift read as a genuine no-match and the old fallback (it

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -838,8 +838,13 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         finally:
             c.close()
         opts = webauthn_lib.generate_registration_options(
-            rp_id=rp, rp_name="membro", user_id=handle, user_name="owner",
-            user_display_name="Membro owner",
+            # "membro owner", not a bare "owner": the three fleet apps share
+            # the localhost RP (RP ids ignore ports), so the system account
+            # picker lists every app's passkey in one sheet and the user name
+            # is the only line it reliably shows (#68; crossband set the
+            # pattern).
+            rp_id=rp, rp_name="membro", user_id=handle,
+            user_name="membro owner", user_display_name="membro owner",
             # Platform authenticator with a discoverable credential and true
             # user verification: Touch ID / Face ID, resident on the device,
             # so login can offer "use a passkey" without disclosing

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -394,3 +394,15 @@ def test_stored_record_is_public_material_only(tmp_path):
     priv = pk.key.private_numbers().private_value.to_bytes(32, "big")
     assert bytes_to_base64url(priv) not in json.dumps(rec)
     assert base64url_to_bytes(rec["id"]) == pk.cred_id
+
+
+def test_registration_names_the_app_in_the_picker(tmp_path):
+    """The three fleet apps share the localhost RP (RP ids ignore ports), so
+    the system account picker lists every app's passkey in one sheet - and
+    the user name is the only line it reliably shows. A bare "owner" is
+    indistinguishable from the siblings' rows (#68)."""
+    c = _owner(_app(tmp_path))
+    o = c.post("/webauthn/register/options", headers={"Origin": LOCAL_ORIGIN})
+    user = o.json()["publicKey"]["user"]
+    assert user["name"] == "membro owner"
+    assert user["displayName"] == "membro owner"


### PR DESCRIPTION
Fixes #68.

The three fleet apps share the `localhost` RP (RP ids ignore ports), so the system account picker lists every app's passkey in one sheet - and the user name is the only line it reliably shows. Membro's row read as a bare "owner", indistinguishable from spendglass's. Crossband set the pattern with "crossband owner"; this mirrors it.

One-line change plus a test pin so it can't regress, and a changelog note: an existing credential keeps its old label until re-enrolled (remove the bare-owner one in the admin Passkeys panel, enrol again).

Suite: 468 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM)_