### PR TITLE
Unlock sheet offers only membro's own passkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- Other apps' passkeys no longer crowd membro's unlock sheet (#70).
+  The fleet's apps share the browser's localhost passkey scope, so the
+  sheet used to offer every app's key here. The gate now tells the
+  browser exactly which keys are membro's own. The trade, made
+  deliberately: the lock screen now names those key ids to anyone who
+  can reach it - an id is a serial number for the key, not a secret,
+  and it cannot unlock anything.
+
 - Your passkey now says whose it is (#68). The system account
   picker lists every localhost app's passkey in one sheet, and
   membro's row used to read as a bare "owner". New enrolments

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -906,11 +906,14 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
 
     @app.post("/webauthn/login/options", include_in_schema=False)
     def webauthn_login_options(request: Request):
-        # Anonymous by design (lock screen), so it discloses as little as the
-        # page itself: a challenge and the RP, never a credential id or key —
-        # allowCredentials stays empty and the browser offers whatever
-        # DISCOVERABLE credential it holds for this RP (resident keys are
-        # required at enrolment for exactly this).
+        # Anonymous by design (lock screen). The sheet is narrowed to THIS
+        # app's own keys: the fleet's apps share the localhost RP (ports
+        # don't count), and with an empty allowCredentials every app's
+        # sheet listed every app's passkey (#70). Naming our enrolled ids
+        # to an anonymous caller is a deliberate disclosure (owner call,
+        # 2026-08-23, reversing the earlier ids-stay-private posture): a
+        # credential id is a public key handle, not a secret, and this
+        # endpoint's 400 already said whether a passkey exists here.
         ctx = _webauthn_context(request)
         if ctx is None:
             raise HTTPException(400, "passkey unlock is not available on this "
@@ -918,13 +921,16 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         origin, rp = ctx
         c = con()
         try:
-            enrolled_here = bool(passkeys.credentials_for_rp(c, rp))
+            rows = passkeys.credentials_for_rp(c, rp)
         finally:
             c.close()
-        if not enrolled_here:
+        if not rows:
             raise HTTPException(400, "no passkey is enrolled for this origin")
         opts = webauthn_lib.generate_authentication_options(
             rp_id=rp,
+            allow_credentials=[
+                PublicKeyCredentialDescriptor(id=base64url_to_bytes(r["id"]))
+                for r in rows],
             user_verification=UserVerificationRequirement.REQUIRED)
         cid = _webauthn_mint("login", opts.challenge, rp, origin)
         return {"cid": cid,

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -217,6 +217,10 @@ def test_lock_screen_offers_passkey_only_where_one_exists(tmp_path):
 
 
 def test_lock_screen_and_options_leak_no_credential_material(tmp_path):
+    """Narrowed since the sheet-scoping change (#70, owner call): the login
+    OPTIONS now deliberately name this app's credential ids, so the line
+    held here is what still matters - the lock PAGE discloses nothing, and
+    no surface ever carries key material."""
     app = _app(tmp_path)
     pk, _ = _enrol_passkey(_owner(app))
     anon = _client(app)
@@ -224,11 +228,10 @@ def test_lock_screen_and_options_leak_no_credential_material(tmp_path):
     options = anon.post("/webauthn/login/options",
                         headers={"Origin": LOCAL_ORIGIN}).json()
     cred_id = bytes_to_base64url(pk.cred_id)
-    for surface in (page, json.dumps(options)):
-        assert cred_id not in surface
-        assert "public_key" not in surface
-    # discoverable credentials: no allowCredentials disclosed at all
-    assert not options["publicKey"].get("allowCredentials")
+    assert cred_id not in page
+    surface = json.dumps(options)
+    assert "public_key" not in surface and "public_key" not in page
+    assert bytes_to_base64url(pk._cose_key()) not in surface
 
 
 def test_password_fallback_still_works_with_passkey_enrolled(tmp_path):
@@ -406,3 +409,17 @@ def test_registration_names_the_app_in_the_picker(tmp_path):
     user = o.json()["publicKey"]["user"]
     assert user["name"] == "membro owner"
     assert user["displayName"] == "membro owner"
+
+
+def test_login_sheet_offers_only_this_apps_keys(tmp_path):
+    """The fleet shares the localhost RP, so an empty allow-list meant every
+    app's sheet offered every app's passkey (#70). The gate now names
+    exactly its own enrolled ids - a deliberate owner-approved disclosure:
+    an id is a key handle, not a secret, and existence was already
+    disclosed by the no-passkey 400."""
+    c = _owner(_app(tmp_path))
+    pk, r = _enrol_passkey(c)
+    assert r.status_code == 200, r.text
+    o = c.post("/webauthn/login/options", headers={"Origin": LOCAL_ORIGIN})
+    allowed = o.json()["publicKey"]["allowCredentials"]
+    assert [a["id"] for a in allowed] == [bytes_to_base64url(pk.cred_id)]


### PR DESCRIPTION
Fixes #70.

The crossband key on membro's sheet wasn't a sync bug: the fleet shares the `localhost` RP and the login options sent an empty allow-list, so the browser offered every localhost passkey everywhere. The gate now sends `allowCredentials` naming exactly membro's enrolled ids - the sheet shows membro's key alone.

Deliberate disclosure, owner call 2026-08-23, reversing the recorded ids-stay-private posture: a credential id is a public key handle, not a secret, and the options endpoint's 400 already told an anonymous caller whether a passkey exists here at all. The old no-leak pin narrows to what still matters (page discloses nothing; no surface carries key material) and a new pin holds the allow-list to exactly this app's ids.

Suite: 469 passed. Siblings: crossband #205-equivalent and spendglass PRs from the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDUK1paKGe4avzshvnVAWM)_