### PR TITLE
Carry updated_at in the persons projection so the delta pull can advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- Person records now report when they last changed (#73). The sync
+  endpoint filters on that stamp, but the records themselves never
+  carried it, so a syncing app could not learn the newest stamp it had
+  seen and re-read every person on every pass. The field the API doc
+  already promised is now in the record.
+
 - Other apps' passkeys no longer crowd membro's unlock sheet (#70).
   The fleet's apps share the browser's localhost passkey scope, so the
   sheet used to offer every app's key here. The gate now tells the

--- a/memory_service/persons.py
+++ b/memory_service/persons.py
@@ -89,6 +89,12 @@ def out(con, person) -> dict:
             "name_owner_set": bool(person["name_owner_set"]),
             "relationship": person["relationship"],
             "created_at": person["created_at"],
+            # The change stamp the delta pull filters on. GET /v1/persons
+            # accepts ?since= against this column, but the projection never
+            # carried it - so a syncing app could not learn the newest stamp
+            # it saw, its watermark sat at zero forever, and every pass
+            # re-read everyone. Additive; absent meant exactly that bug.
+            "updated_at": person["updated_at"],
             "origin_client": person["origin_client"],
             "merged_into": person["merged_into"],
             "forgotten_at": person["forgotten_at"],

--- a/tests/test_person_records.py
+++ b/tests/test_person_records.py
@@ -125,6 +125,22 @@ def test_sync_since_returns_changes_with_forgotten_marks(client):
         "p-b": False, "p-alex1": True}
 
 
+def test_projection_carries_the_change_stamp_the_delta_needs(client):
+    """?since= filters on updated_at, so the projection must carry it - a
+    syncing app records the newest stamp it saw and passes it back as
+    since=. Without the field its watermark sat at zero forever and every
+    pass re-read everyone (the crossband person-sync watermark bug)."""
+    t0 = time.time()
+    time.sleep(0.02)
+    made = _mk(client)
+    assert made["updated_at"] > t0
+    got = client.get("/v1/persons").json()["persons"]
+    assert [p["updated_at"] for p in got] == [made["updated_at"]]
+    # the round trip the delta pull actually makes: newest stamp back in
+    assert client.get("/v1/persons", params={
+        "since": made["updated_at"]}).json()["persons"] == []
+
+
 def test_forget_runs_the_numbered_steps(client, settings):
     # a guest message, a fact mined from it, and a person with that alias
     client.post("/v1/ingest", json={


### PR DESCRIPTION
## What & why

Fixes #73. `GET /v1/persons?since=` filters on `updated_at` and the API doc says records carry "timestamps", but `persons.out()` returned `created_at` only — so a syncing app's watermark sat at zero forever and every pass re-read everyone. Additive field; the new test pins the `since=` round trip a delta pull actually makes.

## Checklist

- [x] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q` (457 passed; 13 pre-existing failures on this container from `math.sumprod` needing Python 3.12, identical on a clean checkout — CI runs 3.12)
- [x] No real personal data anywhere in the diff. Roster names only (Alex, Robin)
- [x] The invariants still hold (append-only; episodic record immutable; quarantine honoured; `tests/test_invariants.py`)
- [x] CHANGELOG.md entry under Unreleased in this same PR
- [x] New UI surfaces have a plain-English explainer: none added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVUthu5Dky2rXut7XyKGCy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVUthu5Dky2rXut7XyKGCy)_