### PR TITLE
Discard snapshots byte-identical to the newest so a crash loop keeps history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+- A crash loop can no longer destroy your restore points (#75). Every
+  startup snapshots the database before migrations, retention keeps the
+  newest 14 copies, and the service manager restarts a crashing app
+  every few seconds - so about two minutes of crash loop used to evict
+  every pre-crash snapshot at exactly the moment one was needed. A
+  snapshot byte-identical to the newest one is now discarded, so
+  restarts that change nothing keep the history intact.
+
 - Other apps' passkeys no longer crowd membro's unlock sheet (#70).
   The fleet's apps share the browser's localhost passkey scope, so the
   sheet used to offer every app's key here. The gate now tells the

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -344,22 +344,50 @@ def set_setting(con, key: str, value: str) -> None:
 
 # ---------- backups ----------
 
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def backup(settings) -> Path | None:
     """One consistent online snapshot; local rotation + optional mirror folder.
-    Only completed static snapshots are mirrored — never the live WAL DB."""
+    Only completed static snapshots are mirrored — never the live WAL DB.
+
+    Content-deduped: a copy byte-identical to the newest snapshot is
+    discarded and the newest snapshot stands. The guard exists for the
+    crash loop: retention keeps the newest backup_keep copies by COUNT,
+    launchd restarts a crashing service every ~10 seconds, and init
+    snapshots pre-migration on every startup - so unguarded, backup_keep
+    restarts (about two minutes) evicted the entire pre-crash history at
+    exactly the moment it was needed. An identical copy protects nothing
+    the standing snapshot does not already protect."""
     if not settings.db_path.exists():
         return None
     bdir = settings.data_dir / "backups"
     bdir.mkdir(parents=True, exist_ok=True)
     dest = bdir / time.strftime("memory-%Y%m%d-%H%M%S.db")
+    tmp = bdir / f".{dest.name}.part"
     src = connect(settings.db_path)
     try:
-        dst = sqlite3.connect(dest)
+        dst = sqlite3.connect(tmp)
         with dst:
             src.backup(dst)
         dst.close()
     finally:
         src.close()
+    prev = sorted(bdir.glob("memory-*.db"))
+    if prev:
+        try:
+            identical = _file_sha256(tmp) == _file_sha256(prev[-1])
+        except OSError:
+            identical = False
+        if identical:
+            tmp.unlink(missing_ok=True)
+            return prev[-1]
+    tmp.replace(dest)
     _rotate(bdir, settings.backup_keep)
     if settings.mirror_dir:
         try:

--- a/tests/test_backup_scheduler.py
+++ b/tests/test_backup_scheduler.py
@@ -63,3 +63,31 @@ def test_stop_event_halts_the_loop(settings, con):
     con.commit()
     time.sleep(0.3)
     assert len(_snaps(settings)) == baseline
+
+
+def test_identical_content_takes_no_new_snapshot(settings, con):
+    first = db_mod.backup(settings)
+    time.sleep(0.05)
+    again = db_mod.backup(settings)
+    assert again == first          # the standing snapshot is the answer
+    assert len(_snaps(settings)) == 1
+
+
+def test_a_crash_loop_no_longer_shreds_the_history(settings, con):
+    """init snapshots pre-migration on every startup, retention keeps the
+    newest backup_keep copies by count, and launchd restarts a crashing
+    service every ~10 seconds - so backup_keep restarts (about two
+    minutes) used to evict the whole pre-crash history at exactly the
+    moment it was needed. Repeated init with nothing changing must not
+    add, evict, or rewrite a snapshot."""
+    con.execute("INSERT INTO conversations(source_app, external_id, created_at) "
+                "VALUES ('t', 'c1', 1700000000.0)")
+    con.commit()
+    db_mod.init(settings)          # one changed startup takes its snapshot
+    before = [(f.name, f.stat().st_mtime_ns) for f in _snaps(settings)]
+    assert before
+    time.sleep(0.05)
+    for _ in range(5):             # the crash loop
+        db_mod.init(settings)
+    after = [(f.name, f.stat().st_mtime_ns) for f in _snaps(settings)]
+    assert after == before


### PR DESCRIPTION
## What & why

Fixes #75. Startup snapshots plus count-based retention plus launchd's ~10s restart meant about two minutes of crash loop evicted every pre-crash restore point; the scheduler's mtime guard cannot cover it because init's own migration writes re-arm it every restart. `backup` now builds the copy to a temp file and discards it when byte-identical to the newest snapshot. Repeated `init` is byte-stable through the online backup API — the crash-loop test pins that and fails on the old code.

## Checklist

- [x] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q` (458 passed; 13 pre-existing failures on this container from `math.sumprod` needing Python 3.12, identical on a clean checkout — CI runs 3.12)
- [x] No real personal data anywhere in the diff
- [x] The invariants still hold (append-only; episodic record immutable; quarantine honoured; `tests/test_invariants.py`)
- [x] CHANGELOG.md entry under Unreleased in this same PR
- [x] New UI surfaces have a plain-English explainer: none added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVUthu5Dky2rXut7XyKGCy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVUthu5Dky2rXut7XyKGCy)_