### PR TITLE
Scan requirements.txt: a published file is never pre-exempt

### DIFF
--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -46,14 +46,15 @@ allow_ts='tail[Xx]{3,}|my-tailnet|<[a-z]+>|example'                       # real
 allow_home='^/(Users|home)/(you|USER|username|user|name|me|<[a-z]+>)$'    # only placeholder home names pass
 allow_email='@example\.(com|org|net)$|@users\.noreply\.github\.com$|^git@github\.com$|^noreply@|<[a-z]+>'
 
-# Paths whose CONTENT is exempt (this scanner, the hook, the fixtures that must
-# contain real-looking strings to be tested, and the version-pinned requirements).
+# Paths whose CONTENT is exempt (this scanner, the hook, and the fixtures
+# that must contain real-looking strings to be tested). requirements.txt was
+# listed here for lockfile noise it never actually contained; it is tracked,
+# it ships, and a published file must not be pre-exempt from every matcher.
 excludes=(
   ':(exclude)scripts/secret-scan.sh'
   ':(exclude).githooks/pre-commit'
   ':(exclude)tests/fixtures/identifiers/*'
   ':(exclude)tests/test_secret_scan.py'
-  ':(exclude)requirements.txt'
 )
 
 mode="staged"

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -267,3 +267,14 @@ def test_tree_scan_clean_against_real_denylist_when_present():
     real = REPO / ".secret-scan-local"
     code, out = run("--tree", local_list=str(real) if real.exists() else None)
     assert code == 0, out
+
+
+# ── published files are never pre-exempt ─────────────────────────────────────
+def test_requirements_txt_is_not_exempt():
+    """requirements.txt is tracked and ships, so it must face every matcher.
+    The exclusion existed for lockfile noise the file never contained, and
+    the pin-with-hash test above proves the matchers ignore that noise
+    anyway. A published file on the exclude list is a silent pre-exemption
+    for whatever lands in it later."""
+    text = (REPO / "scripts" / "secret-scan.sh").read_text()
+    assert ":(exclude)requirements.txt" not in text


### PR DESCRIPTION
## What & why

Fixes #77. The exclusion existed for lockfile noise the file never contained, and the existing pin-with-hash test proves the matchers ignore that noise anyway — so all it did was exempt a tracked, published file from every matcher. Dropped, with a test pinning its absence. `--tree` scan stays green.

## Checklist

- [x] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q` (457 passed; 13 pre-existing failures on this container from `math.sumprod` needing Python 3.12, identical on a clean checkout — CI runs 3.12)
- [x] No real personal data anywhere in the diff
- [x] The invariants still hold (no data-path change)
- [x] CHANGELOG.md: not user-visible (scanner coverage only), no entry
- [x] New UI surfaces have a plain-English explainer: none added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVUthu5Dky2rXut7XyKGCy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVUthu5Dky2rXut7XyKGCy)_