### PR TITLE
Changelog entries become one file per change, folded at release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@
 - [ ] Tests green **keyless**: `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY .venv/bin/python -m pytest tests/ -q`
 - [ ] No real personal data anywhere in the diff. Fleet synthetic roster only: people Alex, Sam, Dave, Mateo; place Fairhaven; companies AcmeCo, Initech, Globex. A name outside the roster is a review question by definition
 - [ ] The invariants still hold (append-only; episodic record immutable; quarantine honoured; `tests/test_invariants.py`)
-- [ ] CHANGELOG.md entry under Unreleased in this same PR if this is user-visible; docs updated if they now lie
+- [ ] `changelog.d/` fragment in this same PR if this is user-visible; docs updated if they now lie
 - [ ] New UI surfaces have a plain-English "what is this & why it matters" explainer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,11 @@ tracker a comment meant.
 ## Rules
 
 - Tests accompany behaviour changes.
-- User-visible changes get a line in `CHANGELOG.md` under Unreleased.
+- User-visible changes get one new file under `changelog.d/`, not an
+  edit to `CHANGELOG.md`. Name it `<issue>-<slug>.md` and write the
+  finished entry: one `- ` paragraph in the changelog's voice, with
+  continuation lines indented two spaces. Entries fold into the
+  changelog at release, so two open PRs never touch the same line.
 - No real personal data in any diff. Fixtures use the documented
   synthetic roster (see the PR template); any name outside it is a
   review question. Enable the leak scanner once per clone:
@@ -97,5 +101,6 @@ Before a tag, every box:
 - [ ] Screenshots and any demo database come from synthetic conversations
       only, including the sidebar: generated titles summarise whatever a
       chat actually discussed
-- [ ] `__version__` bumped, CHANGELOG entry dated, fresh `## Unreleased`
-      left above it
+- [ ] `python scripts/fold_changelog.py vX.Y.Z` run: `changelog.d/`
+      empty, the new section dated, Unreleased left empty above it
+- [ ] `__version__` bumped

--- a/changelog.d/79-changelog-fragments.md
+++ b/changelog.d/79-changelog-fragments.md
@@ -1,0 +1,5 @@
+- Two open PRs no longer conflict on the changelog (#79). Each change
+  now ships its entry as one file under `changelog.d/`, and a release
+  folds them into `CHANGELOG.md` newest first, above the entries already
+  sitting under Unreleased. A test fails any PR that edits Unreleased
+  directly and names the new home.

--- a/scripts/fold_changelog.py
+++ b/scripts/fold_changelog.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Fold changelog.d fragments into CHANGELOG.md for a release (#79).
+
+Unreleased entries live as one file per change under changelog.d/, so two
+open PRs never edit the same line of CHANGELOG.md. This script runs at
+release: it moves every fragment into the new version's section, newest
+first, above any entries already sitting under Unreleased, and leaves a
+fresh empty Unreleased behind.
+
+Usage:
+    python scripts/fold_changelog.py v0.3.0 [--date 2026-09-01]
+
+The date defaults to today. The script edits CHANGELOG.md and deletes the
+fragments; review the diff and commit it as part of the release PR.
+"""
+import argparse
+import datetime
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+FRAGMENT_DIR = REPO / "changelog.d"
+FRAGMENT_NAME = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*\.md$")
+
+
+def split_unreleased(text):
+    """(before, preamble, entries, after) around the Unreleased section.
+
+    The preamble is whatever prose sits under the heading before the first
+    entry; the entries run from the first `- ` line to the next `## `
+    heading. One parse shared with the tests, so the guard and the fold can
+    never disagree about where an entry is."""
+    m = re.search(r"^## Unreleased\n(.*?)(?=^## )", text, re.M | re.S)
+    if not m:
+        raise SystemExit("CHANGELOG.md has no Unreleased section")
+    body = m.group(1)
+    e = re.search(r"^- ", body, re.M)
+    preamble, entries = (body, "") if not e else (body[: e.start()], body[e.start():])
+    return text[: m.start(1)], preamble, entries, text[m.end(1):]
+
+
+def fragment_problems(name, body):
+    """Why this fragment cannot fold, or an empty list. An entry is one
+    `- ` paragraph; continuation lines are blank or indented two spaces,
+    exactly as they would sit in CHANGELOG.md."""
+    problems = []
+    if not FRAGMENT_NAME.match(name):
+        problems.append("name must be lowercase-hyphen words ending .md, "
+                        "e.g. 277-changelog-fragments.md")
+    lines = body.splitlines()
+    if not lines or not lines[0].startswith("- "):
+        problems.append("the first line must start with '- '")
+    for ln in lines[1:]:
+        if ln.startswith("- "):
+            problems.append("one entry per fragment; a second change gets "
+                            "its own file")
+            break
+        if ln and not ln.startswith("  "):
+            problems.append("continuation lines are indented two spaces")
+            break
+    if body and not body.endswith("\n"):
+        problems.append("the file must end with a newline")
+    return problems
+
+
+def fold(text, fragment_bodies, version, date):
+    """The folded CHANGELOG text. fragment_bodies arrive newest first and
+    land above any entries already under Unreleased, which are already in
+    their final order."""
+    before, preamble, entries, after = split_unreleased(text)
+    parts = [b.rstrip("\n") for b in fragment_bodies]
+    if entries.strip():
+        parts.append(entries.strip("\n"))
+    section = f"## {version} ({date})\n\n" + "\n\n".join(parts) + "\n\n"
+    return before + preamble + section + after
+
+
+def _added_ts(path):
+    """When git first saw this fragment, for newest-first ordering. A file
+    git has never seen sorts newest, which is where a just-written entry
+    belongs."""
+    r = subprocess.run(
+        ["git", "log", "--diff-filter=A", "--format=%ct", "-1", "--",
+         str(path.relative_to(REPO))],
+        cwd=REPO, capture_output=True, text=True)
+    out = r.stdout.strip()
+    return int(out) if r.returncode == 0 and out else float("inf")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("version", help="e.g. v0.3.0")
+    ap.add_argument("--date", default=datetime.date.today().isoformat())
+    args = ap.parse_args(argv)
+
+    fragments = sorted(FRAGMENT_DIR.glob("*.md"))
+    if not fragments:
+        raise SystemExit("changelog.d/ holds no fragments; nothing to fold")
+    bad = {}
+    for f in fragments:
+        problems = fragment_problems(f.name, f.read_text())
+        if problems:
+            bad[f.name] = problems
+    if bad:
+        for name, problems in bad.items():
+            print(f"{name}: " + "; ".join(problems), file=sys.stderr)
+        raise SystemExit("fix the fragments above, then rerun")
+
+    fragments.sort(key=lambda f: (_added_ts(f), f.name), reverse=True)
+    changelog = REPO / "CHANGELOG.md"
+    changelog.write_text(fold(changelog.read_text(),
+                              [f.read_text() for f in fragments],
+                              args.version, args.date))
+    for f in fragments:
+        f.unlink()
+    print(f"folded {len(fragments)} fragment(s) into {args.version}; "
+          "review the diff and commit")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_changelog_fragments.py
+++ b/tests/test_changelog_fragments.py
@@ -18,7 +18,7 @@ FRAGMENT_DIR = REPO / "changelog.d"
 # The entries sitting under Unreleased when fragments arrived. They stay
 # byte-identical until a release folds them away; any change means someone
 # added an entry the old way, which is the conflict machine coming back.
-FROZEN_SHA = "e2f9aca8b5337243d29562a20e5b3cfa6bbe2a7b167aab36467d6dbd17f98e8a"
+FROZEN_SHA = "a3dee3aad7dba6d69bd224ee0e4e78f3c1e896c5e377af92cc4c0372e4648efa"
 
 
 def _fold():

--- a/tests/test_changelog_fragments.py
+++ b/tests/test_changelog_fragments.py
@@ -1,0 +1,105 @@
+"""Changelog fragments: two open PRs must never conflict on CHANGELOG.md (#79).
+
+Every PR used to insert its entry at the same line, the top of Unreleased,
+so any two open PRs conflicted there whatever else they touched. Entries now
+ship as one file each under changelog.d/ and fold into CHANGELOG.md at
+release, via scripts/fold_changelog.py. These tests pin the three things
+that keep that true: Unreleased gains no new entries directly, every
+fragment can actually fold, and the fold puts fragments where the reader
+expects them.
+"""
+import hashlib
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+FRAGMENT_DIR = REPO / "changelog.d"
+
+# The entries sitting under Unreleased when fragments arrived. They stay
+# byte-identical until a release folds them away; any change means someone
+# added an entry the old way, which is the conflict machine coming back.
+FROZEN_SHA = "e2f9aca8b5337243d29562a20e5b3cfa6bbe2a7b167aab36467d6dbd17f98e8a"
+
+
+def _fold():
+    spec = importlib.util.spec_from_file_location(
+        "fold_changelog", REPO / "scripts" / "fold_changelog.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_unreleased_gains_no_new_entries_directly():
+    """The guard. A user-visible change adds a file under changelog.d/, and
+    CHANGELOG.md's Unreleased section stays exactly as the conversion froze
+    it until a release empties it."""
+    mod = _fold()
+    _, _, entries, _ = mod.split_unreleased((REPO / "CHANGELOG.md").read_text())
+    if not entries.strip():
+        return  # a release folded everything away; nothing to guard
+    assert hashlib.sha256(entries.encode()).hexdigest() == FROZEN_SHA, (
+        "CHANGELOG.md's Unreleased section changed. New entries go in "
+        "changelog.d/ as one file per change (see CONTRIBUTING.md); move "
+        "the entry there and revert the CHANGELOG edit."
+    )
+
+
+def test_every_fragment_can_fold():
+    """A fragment that cannot fold is a release-day surprise. Catch it in
+    the PR that adds it instead."""
+    mod = _fold()
+    problems = {
+        f.name: p
+        for f in sorted(FRAGMENT_DIR.glob("*.md"))
+        if (p := mod.fragment_problems(f.name, f.read_text()))
+    }
+    assert not problems, problems
+
+
+def test_fold_puts_fragments_above_the_frozen_entries():
+    """Newest first is the file's law. Fragments are newer than anything
+    already under Unreleased, so they land above it in the new section."""
+    mod = _fold()
+    changelog = (
+        "# Changelog\n\nHouse convention.\n\n"
+        "## Unreleased\n\nPointer paragraph.\n\n"
+        "- Old entry, already placed (#1).\n\n"
+        "## v0.1.0 (2026-08-06)\n\n- Ancient (#0).\n"
+    )
+    out = mod.fold(changelog, ["- Newer (#3).\n", "- New (#2).\n"],
+                   "v0.2.0", "2026-09-01")
+    section = out.split("## v0.2.0 (2026-09-01)\n")[1].split("## v0.1.0")[0]
+    order = [ln for ln in section.splitlines() if ln.startswith("- ")]
+    assert order == ["- Newer (#3).", "- New (#2).",
+                     "- Old entry, already placed (#1)."], order
+    assert "\n\n\n" not in out
+
+
+def test_fold_leaves_a_fresh_empty_unreleased_that_passes_the_guard():
+    """After a release the guard's empty branch takes over, so the release
+    never has to edit this test. Pin that the folded file really does read
+    as empty to the same parser."""
+    mod = _fold()
+    changelog = (
+        "# Changelog\n\n"
+        "## Unreleased\n\nPointer paragraph.\n\n"
+        "- Old entry (#1).\n\n"
+        "## v0.1.0 (2026-08-06)\n\n- Ancient (#0).\n"
+    )
+    out = mod.fold(changelog, ["- New (#2).\n"], "v0.2.0", "2026-09-01")
+    _, preamble, entries, _ = mod.split_unreleased(out)
+    assert "Pointer paragraph." in preamble
+    assert entries == ""
+
+
+def test_fragment_rules_name_each_problem():
+    """The problems list is what a contributor sees in CI; each rule speaks
+    once and plainly."""
+    mod = _fold()
+    assert mod.fragment_problems("79-changelog-fragments.md",
+                                 "- One entry (#79).\n  Indented tail.\n") == []
+    assert mod.fragment_problems("Bad_Name.md", "- Fine (#1).\n")
+    assert mod.fragment_problems("ok.md", "not an entry\n")
+    assert mod.fragment_problems("ok.md", "- One (#1).\n- Two (#2).\n")
+    assert mod.fragment_problems("ok.md", "- One (#1).\nno indent\n")
+    assert mod.fragment_problems("ok.md", "- No newline (#1).")


### PR DESCRIPTION
## What & why

Fixes #79. Every user-visible PR edits the top of CHANGELOG.md's Unreleased section, so any two open PRs conflict there whatever else they touch. Entries now ship as one file each under `changelog.d/` and fold into the changelog at release, the same system that held crossband through a twelve-PR day with zero changelog conflicts. Ported unchanged from crossband#277.

New: `scripts/fold_changelog.py` (run at release) and `tests/test_changelog_fragments.py` (freezes today's Unreleased bytes, fails any PR that edits it directly with a message naming the new home, validates every fragment can fold). Proven by planting an entry in Unreleased and watching the guard fail. CONTRIBUTING's change rule, the release checklist and the PR template checkbox now point at `changelog.d/`.

## Checklist

- [x] Tests green **keyless**: the five new fragment tests and doc-style pass; the full run is 463 passed with 13 failures in test_viz and friends that fail identically on clean `main` in this container (fresh unpinned venv), so they are not this PR's
- [x] No real personal data anywhere in the diff
- [x] The invariants still hold (append-only; episodic record immutable; quarantine honoured) - nothing outside docs, scripts and tests changed
- [x] `changelog.d/` fragment in this same PR: `changelog.d/79-changelog-fragments.md`
- [x] New UI surfaces: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvGD94orocaKwSLTEGtZN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvGD94orocaKwSLTEGtZN1)_