### PR TITLE
Gate MCP search_history behind the owner token

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,9 @@ assertion is accepted only for `localhost` or a host listed in
 ## Open vs gated
 
 Gated even on loopback: everything reading or writing exact rows
-(facts, review, verbatim search, attachments, jobs, consolidate).
+(facts, review, verbatim search, attachments, jobs, consolidate). The
+MCP server honours the same rule: `search_history` works only when the
+token was passed at registration.
 
 Open on loopback: `/v1/recall` (six fields, max 50 rows),
 `/v1/summary` and its version list, `/v1/health`,

--- a/changelog.d/81-mcp-search-gate.md
+++ b/changelog.d/81-mcp-search-gate.md
@@ -1,0 +1,5 @@
+- Verbatim transcript search now needs the owner token on every path
+  (#81). The MCP server's search_history refuses when the server was
+  registered without MEMORY_AUTH_TOKEN, matching the HTTP gate; recall,
+  summary and save are unchanged. Re-register the server with the token
+  to keep search available to your own tools.

--- a/memory_service/mcp_server.py
+++ b/memory_service/mcp_server.py
@@ -8,8 +8,12 @@ nothing external becomes canon without human review.
 Register with (the variables must be passed with -e so they reach the SERVER
 when it runs; a shell prefix before `claude mcp add` would only set them for
 the registration command itself):
-    claude mcp add -s user membro -e PYTHONPATH=<repo> -- \
+    claude mcp add -s user membro -e PYTHONPATH=<repo> \
+        -e MEMORY_AUTH_TOKEN=<the service's token> -- \
         <repo>/.venv/bin/python -m memory_service.mcp_server
+
+MEMORY_AUTH_TOKEN enables search_history (#81); without it the owner-gated
+verbatim search refuses while the other three tools work as ever.
 """
 
 import datetime
@@ -67,7 +71,13 @@ def recall_memory(query: str = "") -> str:
 @mcp.tool()
 def search_history(query: str) -> str:
     """Verbatim full-text search across every ingested message in the user's
-    conversation history."""
+    conversation history. Owner-gated like the HTTP route (#81): register the
+    server with -e MEMORY_AUTH_TOKEN=<the service's token> to enable it."""
+    if SETTINGS.auth_token and (
+            os.environ.get("MEMORY_AUTH_TOKEN") != SETTINGS.auth_token):
+        return ("Verbatim transcript search is owner-gated: this MCP server "
+                "was registered without the owner's MEMORY_AUTH_TOKEN, so "
+                "search_history is unavailable. recall_memory still works.")
     con = _con()
     try:
         hits = episodic.search(con, query)

--- a/tests/test_mcp_save_memory.py
+++ b/tests/test_mcp_save_memory.py
@@ -60,3 +60,38 @@ def test_save_memory_records_drop_diagnostics_by_reason():
     mcp_server.save_memory("Merged pull request #7 after CI went green.")
     after = walls.drop_diagnostics()
     assert after.get("builder-process", 0) == before.get("builder-process", 0) + 1
+
+
+# ---------- search_history honours the owner gate (#81) ----------
+
+def test_search_history_refuses_without_the_owner_token(con, settings,
+                                                        monkeypatch):
+    """The HTTP route requires the bearer; the MCP path used to require
+    nothing. With a token configured and none in the server's environment,
+    the tool refuses and touches nothing."""
+    monkeypatch.setattr(settings, "auth_token", "owner-tok")
+    monkeypatch.delenv("MEMORY_AUTH_TOKEN", raising=False)
+    called = []
+    monkeypatch.setattr(mcp_server.episodic, "search",
+                        lambda *a, **k: called.append(a) or [])
+    out = mcp_server.search_history("anything")
+    assert "owner-gated" in out and "recall_memory" in out
+    assert called == []
+
+
+def test_search_history_works_with_the_matching_token(con, settings,
+                                                      monkeypatch):
+    monkeypatch.setattr(settings, "auth_token", "owner-tok")
+    monkeypatch.setenv("MEMORY_AUTH_TOKEN", "owner-tok")
+    monkeypatch.setattr(mcp_server.episodic, "search", lambda *a, **k: [])
+    assert mcp_server.search_history("anything") == "No matching messages."
+
+
+def test_search_history_stays_open_with_no_token_configured(con, settings,
+                                                            monkeypatch):
+    """An install that never configured a token keeps its open posture,
+    matching the HTTP gate."""
+    monkeypatch.setattr(settings, "auth_token", None)
+    monkeypatch.delenv("MEMORY_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(mcp_server.episodic, "search", lambda *a, **k: [])
+    assert mcp_server.search_history("anything") == "No matching messages."


### PR DESCRIPTION
## What & why

Fixes #81 (workbench#58, decided). Verbatim transcript search required the owner token over HTTP and nothing over MCP, and the MCP server is exactly what gets mounted into other tools. `search_history` now refuses when the service has a token configured and the server's environment does not carry a matching `MEMORY_AUTH_TOKEN`; an install with no token keeps its open posture, matching HTTP. `recall_memory`, `memory_summary` and `save_memory` are untouched. The registration instructions gain the `-e MEMORY_AUTH_TOKEN` line and SECURITY.md now states the rule covers the MCP path.

To keep transcript search available to your own tools, re-register the membro MCP server once with the token.

## Checklist

- [x] Tests green **keyless**: MCP, fragment and doc-style suites (22) on this head, including three new tests: refusal without the token touches nothing, a matching token searches, no configured token stays open
- [x] No real personal data anywhere in the diff
- [x] The invariants still hold (append-only; episodic record immutable; quarantine honoured): read path only
- [x] `changelog.d/` fragment in this same PR: `changelog.d/81-mcp-search-gate.md`
- [x] New UI surfaces: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvGD94orocaKwSLTEGtZN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvGD94orocaKwSLTEGtZN1)_