### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ entry to a short paragraph; the issue holds the detail.
 
 ## Unreleased
 
+## v0.2.0 (2026-08-30)
+
+- Verbatim transcript search now needs the owner token on every path
+  (#81). The MCP server's search_history refuses when the server was
+  registered without MEMORY_AUTH_TOKEN, matching the HTTP gate; recall,
+  summary and save are unchanged. Re-register the server with the token
+  to keep search available to your own tools.
+
+- Two open PRs no longer conflict on the changelog (#79). Each change
+  now ships its entry as one file under `changelog.d/`, and a release
+  folds them into `CHANGELOG.md` newest first, above the entries already
+  sitting under Unreleased. A test fails any PR that edits Unreleased
+  directly and names the new home.
+
 - Person records now report when they last changed (#73). The sync
   endpoint filters on that stamp, but the records themselves never
   carried it, so a syncing app could not learn the newest stamp it had

--- a/changelog.d/79-changelog-fragments.md
+++ b/changelog.d/79-changelog-fragments.md
@@ -1,5 +1,0 @@
-- Two open PRs no longer conflict on the changelog (#79). Each change
-  now ships its entry as one file under `changelog.d/`, and a release
-  folds them into `CHANGELOG.md` newest first, above the entries already
-  sitting under Unreleased. A test fails any PR that edits Unreleased
-  directly and names the new home.

--- a/changelog.d/81-mcp-search-gate.md
+++ b/changelog.d/81-mcp-search-gate.md
@@ -1,5 +1,0 @@
-- Verbatim transcript search now needs the owner token on every path
-  (#81). The MCP server's search_history refuses when the server was
-  registered without MEMORY_AUTH_TOKEN, matching the HTTP gate; recall,
-  summary and save are unchanged. Re-register the server with the token
-  to keep search available to your own tools.

--- a/memory_service/__init__.py
+++ b/memory_service/__init__.py
@@ -10,4 +10,4 @@ Two version numbers, deliberately independent:
   the surface it speaks to.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"


### PR DESCRIPTION
## What & why

The first tagged release since v0.1.1, covering the person-records wave, passkeys, the erasure work, the changelog fragments and the MCP search gate. Folds both fragments into a dated `## v0.2.0 (2026-08-30)` section above the entries frozen at the fragment conversion; Unreleased is empty again and the guard's empty branch takes over. `__version__` moves to 0.2.0. The HTTP `contract_version` stays 1.3: nothing on the wire changed.

After merge I can push the `v0.2.0` tag, or you can create the release from the app.

## Checklist

- [x] Suite keyless: 468 passed; the 13 failures in test_viz and friends fail identically on clean `main` in this container (fresh unpinned venv) and are not this PR's
- [x] `pip-audit -r requirements.txt --strict` clean
- [x] `bash scripts/secret-scan.sh --tree` green (personal-content class skipped here, no `.secret-scan-local`)
- [x] `python scripts/fold_changelog.py v0.2.0` run: `changelog.d/` empty, the new section dated, Unreleased left empty above it
- [x] `__version__` bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvGD94orocaKwSLTEGtZN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvGD94orocaKwSLTEGtZN1)_