### PR TITLE
Dependabot: pip majors need a deliberate PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,10 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule: { interval: weekly }
+    # A major bump is a reviewed change, never a rebase side effect (#85).
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: /
     schedule: { interval: weekly }


### PR DESCRIPTION
Fixes #85.

The pip entry in dependabot.yml now ignores semver-major updates, so a rebase can no longer widen a floor across a major the way the anthropic bump did on 2026-09-02. Minor and patch floors keep flowing; GitHub Actions bumps are unchanged.

Config only, not user-visible, so no changelog fragment. No service restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CecQ4d7xYLwfbCWTSQi5cD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CecQ4d7xYLwfbCWTSQi5cD)_