### PR TITLE
Memory contract 1.4: provenance out, a browser origin, a watermark route, calendar-day event_date

### DIFF
--- a/changelog.d/84-contract-1-4.md
+++ b/changelog.d/84-contract-1-4.md
@@ -1,0 +1,12 @@
+- Memory contract 1.4 (#84): four additive changes so a client app can
+  close seams the 2026-08-28 fleet audit found. `/search` hits carry
+  `web_sources`, the domains the authoring turn read from, so archived
+  web text can be marked untrusted when read back. `/health` reports
+  `browser_origin`, the address a phone can open this service at, so a
+  client links the eraser somewhere that works. A new
+  `/conversations/{app}/{id}/watermark` route reports the highest
+  message id held (erased ones included), so a client can wind its
+  ingest watermark back after a restore instead of leaving a silent
+  hole. `event_date` is now a calendar day at the owner's local
+  midnight for every writer, with same-day recall ties broken on the
+  save time. A 1.3 client keeps working unchanged.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# Memory Service API: the HTTP contract, v1.3
+# Memory Service API: the HTTP contract, v1.4
 
 The contract between Membro and its clients. Owned by this repo.
 Versioned; breaking changes bump the major version. Clients check `contract_version`
@@ -10,6 +10,12 @@ repo's CI (against the real service) and in each client's CI (against the stub).
 - Base URL: `http://127.0.0.1:8901/v1`
 - Local-only: the server refuses to bind a non-loopback address unless
   `MEMORY_AUTH_TOKEN` is set (then: `Authorization: Bearer <token>`).
+- **1.4 (#84): four additive fields for a client that reads memory
+  back.** `/search` hits carry `web_sources`. `/health` carries
+  `browser_origin`. `GET /conversations/{app}/{id}/watermark` reports the
+  highest message id held for one conversation. `event_date` is a
+  calendar day at the owner's local midnight, whichever writer set it.
+  A 1.3 client sees nothing new and keeps working.
 - **1.3 (#55): messages on `/ingest` and saves on `POST /facts` may carry
   `web_sources`**: the web domains a tool read in the round that produced
   the message or save (a list of strings, max 20). Stored verbatim beside
@@ -84,7 +90,8 @@ at the end of it.
 ```json
 {
   "status": "ok|degraded",
-  "contract_version": "1.3",
+  "contract_version": "1.4",
+  "browser_origin": "http://127.0.0.1:8901",
   "db": {"facts": 0, "messages": 0, "size_bytes": 0, "integrity": "ok",
           "fts_in_sync": true, "last_backup_at": null},
   "capabilities": {"embeddings": true, "miner_model": "claude-haiku-4-5"},
@@ -104,7 +111,14 @@ without erroring. The service detects and repairs this automatically at
 startup; `scripts/rebuild_fts.py` does the same for a live instance without a
 restart. A client seeing `fts_in_sync: false` should treat search results as
 unreliable until it flips back, not as an empty archive.
-`status`, `contract_version`, `db` and `capabilities` are contractual.
+`browser_origin` (1.4) is the address a browser can open this service
+at: the `browser_origin` setting when the operator set one, else
+`https://<first trusted host>:<tailscale_port>` when the browser surface
+is admitted from a tailnet name, else loopback. A client app that links
+a person to the admin surface, such as the message eraser, uses this
+instead of guessing a host and port.
+`status`, `contract_version`, `browser_origin`, `db` and `capabilities`
+are contractual.
 `detail` is NOT. It carries the whole internal health dict for the admin
 page's health panel, and may change without a contract bump: sqlite version,
 journal mode, integrity, size, a facts breakdown of
@@ -390,11 +404,30 @@ as revealing as the exact-row ledger reads gated above.
 {"query": "...", "limit": 20}
 ```
 → `{"hits": [{"conversation_id": "...", "title": "...", "speaker": "...",
-              "content": "...", "created_at": "..."}]}`
+              "content": "...", "created_at": "...",
+              "web_sources": ["example.com"]}]}`
 `limit` defaults to 20, maximum 500 (422 outside 1–500). `title` is the
 conversation's title as last ingested (empty string if the client never sent
 one); `content` is an FTS snippet with `>>match<<` markers, not the whole
-message.
+message. `web_sources` (1.4) is the list stored with the message on
+ingest, empty for a turn that read no web page and for hits from files.
+A client that shows a hit to a model should mark a stamped hit as
+untrusted, the same way it marks a live fetch.
+
+### Ingest watermark
+
+`GET /conversations/{source_app}/{conversation_id}/watermark` (1.4). Open
+on loopback like `/health`; it carries ids and a count, never content.
+→ `{"highest_external_id": "412", "messages": 87}`
+`highest_external_id` is the largest message `external_id` this service
+holds for that conversation, compared numerically when every id is an
+integer string and as text otherwise, or `null` when none is held. A
+message the owner erased still counts: its id sits in the erasure
+journal, and a client that wound back past it would re-send the exact
+message just erased. 404 in the standard envelope when the conversation
+is unknown here. A client that keeps its own "ingested up to" mark
+compares the two on each handoff and winds its mark back when this
+service has less, which is what a restore from a snapshot leaves behind.
 
 ## Ledger
 
@@ -406,8 +439,12 @@ message.
 ```
 `content` is whitespace-collapsed first, then must be 8–10 000 characters;
 anything shorter or longer is a 422 ("nothing meaningful to save" / "fact too
-long"). `event_date` is optional: omit it and the fact is dated the moment it
-was saved, which is how invariant 5 holds (`event_date` is never null).
+long"). `event_date` is a calendar day (1.4): send `YYYY-MM-DD`, or a
+full timestamp and the service keeps only the day it falls on in the
+owner's local time. It is stored as that day's local midnight, so two
+facts about one day compare equal and recall breaks the tie on the save
+time. Omit it and the fact is dated to the day it was saved, which is
+how invariant 5 holds (`event_date` is never null).
 `source_app` is what the gate reads below; `confidence` defaults to `high`
 and `origin_agent` to `user`.
 

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -254,6 +254,14 @@ def _ts(iso: str | None) -> float | None:
         raise HTTPException(422, f"bad date: {iso!r}")
 
 
+def _event_day(iso: str | None) -> float | None:
+    """`event_date` on the wire is a calendar day (contract 1.4, #84). A
+    bare date is that day; a full timestamp is the day it falls on in the
+    owner's local time. Either way the stored value is local midnight."""
+    ts = _ts(iso)
+    return None if ts is None else db.day_start(ts)
+
+
 LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 # The ONLY paths a browser may reach unauthenticated on a trusted (tailnet)
@@ -1039,6 +1047,9 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         return {
             "status": "ok" if ok else "degraded",
             "contract_version": settings.contract_version,
+            # 1.4 (#84): where a phone's browser can open this service, so a
+            # client app links the eraser at an address that works.
+            "browser_origin": settings.reachable_browser_origin(),
             "db": {"facts": h["facts"]["total"], "messages": h["messages"],
                     "size_bytes": h["size_bytes"], "integrity": h["integrity"],
                     "fts_in_sync": h["fts_in_sync"],
@@ -1084,6 +1095,20 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         return {"ingested": res["ingested"], "skipped": res["skipped"],
                 "attached": res["attached"]}
 
+    @app.get("/v1/conversations/{source_app}/{conversation_id}/watermark")
+    def conversation_watermark(source_app: str, conversation_id: str):
+        # 1.4 (#84, workbench#68): content-free, open like /health. A client
+        # compares this with its own ingest watermark and winds back when
+        # a restore left this record behind. 404 when unknown here.
+        c = con()
+        try:
+            out = episodic.watermark(c, source_app, conversation_id)
+        finally:
+            c.close()
+        if out is None:
+            raise HTTPException(404, "no such conversation")
+        return out
+
     @app.post("/v1/distill", status_code=202)
     def distill(body: DistillBody):
         def _work():
@@ -1122,7 +1147,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
                 c, body.content, settings, source="model" if
                 body.origin_agent != "user" else "user",
                 origin_agent=body.origin_agent, source_app=body.source_app,
-                event_date=_ts(body.event_date), confidence=body.confidence,
+                event_date=_event_day(body.event_date), confidence=body.confidence,
                 web_sources=body.web_sources)
         except ValueError as e:
             raise HTTPException(422, str(e))
@@ -1144,7 +1169,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
         c = con()
         try:
             ok = ledger.update_fact(c, fact_id, content=body.content,
-                                    event_date=_ts(body.event_date),
+                                    event_date=_event_day(body.event_date),
                                     confidence=body.confidence,
                                     importance=body.importance,
                                     settings=settings)

--- a/memory_service/config.py
+++ b/memory_service/config.py
@@ -71,11 +71,31 @@ class Settings(BaseModel):
     trusted_apps: list[str] = []  # register your own client app slugs; empty = no app-trusted writes
     grounding_allowlist: list[str] = []    # user-specific ubiquitous nouns, config not code
 
-    contract_version: str = "1.3"  # 1.3 (#55): web_sources on ingest + facts; 1.2 (#33): speaker_identity on ingest
+    # 1.4 (#84): web_sources on /search hits, browser_origin on /health, the
+    # per-conversation watermark route, event_date as a calendar day.
+    # 1.3 (#55): web_sources on ingest + facts. 1.2 (#33): speaker_identity.
+    contract_version: str = "1.4"
+    # The origin a browser on a phone can reach this service at, reported on
+    # /v1/health as `browser_origin` (contract 1.4) so a client app links the
+    # admin surface at an address that works instead of guessing a port.
+    # Empty (the default) derives it: https on `tailscale_port` at the first
+    # trusted host when the browser surface is admitted from a tailnet name,
+    # otherwise loopback on `port`.
+    browser_origin: str = ""
+    tailscale_port: int = 8443  # scripts/tailscale-serve.sh's default
 
     @property
     def db_path(self) -> Path:
         return self.data_dir / "memory.db"
+
+    def reachable_browser_origin(self) -> str:
+        """Where a browser can open this service: the operator's explicit
+        value, else the tailnet address when one is trusted, else loopback."""
+        if self.browser_origin.strip():
+            return self.browser_origin.strip().rstrip("/")
+        if self.trusted_hosts:
+            return f"https://{self.trusted_hosts[0]}:{self.tailscale_port}"
+        return f"http://127.0.0.1:{self.port}"
 
 
 def load_settings() -> Settings:
@@ -92,6 +112,10 @@ def load_settings() -> Settings:
         merged["trusted_hosts"] = [h.strip().lower()
                                    for h in os.environ["MEMORY_TRUSTED_HOSTS"].split(",")
                                    if h.strip()]
+    if os.environ.get("MEMORY_BROWSER_ORIGIN"):
+        merged["browser_origin"] = os.environ["MEMORY_BROWSER_ORIGIN"]
+    if os.environ.get("MEMORY_TAILSCALE_PORT"):
+        merged["tailscale_port"] = int(os.environ["MEMORY_TAILSCALE_PORT"])
     if os.environ.get("MEMORY_DATA_DIR"):
         merged["data_dir"] = os.environ["MEMORY_DATA_DIR"]
     if os.environ.get("MEMORY_MIRROR_DIR"):

--- a/memory_service/db.py
+++ b/memory_service/db.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import sqlite3
 import threading
+import datetime
 import time
 from pathlib import Path
 
@@ -324,6 +325,15 @@ def repair_fts(con: sqlite3.Connection) -> dict:
 
 def now() -> float:
     return time.time()
+
+
+def day_start(ts: float) -> float:
+    """The owner's local midnight for the calendar day `ts` falls on.
+    `event_date` is a calendar day (contract 1.4, workbench#63): every
+    writer anchors it here, so two facts about the same day compare equal
+    and recall breaks the tie on `created_at`, the save time."""
+    d = datetime.datetime.fromtimestamp(ts)
+    return d.replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
 
 
 def content_hash(text: str) -> str:

--- a/memory_service/episodic.py
+++ b/memory_service/episodic.py
@@ -16,6 +16,7 @@ import hashlib
 import io
 import logging
 import os
+import re
 
 from . import db
 
@@ -134,6 +135,39 @@ def ingest(con, source_app: str, conversation_external_id: str,
             "skipped": skipped, "attached": attached}
 
 
+_ERASED_REF = re.compile(r"\bref:(\S+)$")
+
+
+def watermark(con, source_app: str, conversation_external_id: str) -> dict | None:
+    """Contract 1.4 (#84, workbench#68): the highest message external_id this
+    service holds for one conversation, so a client can wind its own ingest
+    watermark back after a restore rolled this record back. None when the
+    conversation is unknown here. Erased messages count as held: their ids
+    stay in the erasure journal, and a client that re-sent them would undo
+    the owner's erasure. Compared numerically when every id is an integer
+    string, as text otherwise."""
+    conv = get_conversation(con, source_app, conversation_external_id)
+    if conv is None:
+        return None
+    ids = [r[0] for r in con.execute(
+        "SELECT external_id FROM messages WHERE conversation_id=?", (conv["id"],))]
+    held = len(ids)
+    prefix = f"conv:{source_app}/{conversation_external_id} "
+    for (ref,) in con.execute(
+            "SELECT ref FROM erasures WHERE kind='message' AND instr(ref, ?) > 0",
+            (prefix,)):
+        m = _ERASED_REF.search(ref)
+        if m:
+            ids.append(m.group(1))
+    if not ids:
+        return {"highest_external_id": None, "messages": 0}
+    if all(i.isdigit() for i in ids):
+        highest = max(ids, key=int)
+    else:
+        highest = max(ids)
+    return {"highest_external_id": highest, "messages": held}
+
+
 def get_conversation(con, source_app: str, external_id: str) -> dict | None:
     row = con.execute(
         "SELECT * FROM conversations WHERE source_app=? AND external_id=?",
@@ -152,11 +186,29 @@ def _like_fallback(con, words, limit) -> list[dict]:
     Serves FTS syntax edge cases and a drifted index alike."""
     rows = con.execute(
         "SELECT m.speaker, m.created_at, c.title, c.external_id conversation_id, "
-        "substr(m.content, 1, 200) AS content "
+        "substr(m.content, 1, 200) AS content, m.web_sources "
         "FROM messages m JOIN conversations c ON c.id = m.conversation_id "
         "WHERE m.content LIKE ? ORDER BY m.id DESC LIMIT ?",
         (f"%{words[0]}%", limit))
-    return [dict(r) for r in rows]
+    return _with_web_sources([dict(r) for r in rows])
+
+
+def _with_web_sources(hits: list[dict]) -> list[dict]:
+    """Contract 1.4 (#84): every hit carries `web_sources`, the domains the
+    authoring round read from, as a list (empty when the turn read no web
+    page, and for attachment hits). The stored column is json text or ''."""
+    for h in hits:
+        raw = h.get("web_sources") or ""
+        webs = []
+        if isinstance(raw, str) and raw:
+            try:
+                webs = [str(w) for w in json.loads(raw) if str(w).strip()]
+            except ValueError:
+                webs = []
+        elif isinstance(raw, list):
+            webs = [str(w) for w in raw]
+        h["web_sources"] = webs
+    return hits
 
 
 def _fts_index_drifted(con) -> bool:
@@ -193,7 +245,8 @@ def search(con, query: str, limit: int = 20) -> list[dict]:
     try:
         rows = con.execute(
             "SELECT m.speaker, m.created_at, c.title, c.external_id conversation_id, "
-            "snippet(messages_fts, 0, '>>', '<<', ' … ', 24) AS content "
+            "snippet(messages_fts, 0, '>>', '<<', ' … ', 24) AS content, "
+            "m.web_sources "
             "FROM messages_fts JOIN messages m ON m.id = messages_fts.rowid "
             "JOIN conversations c ON c.id = m.conversation_id "
             "WHERE messages_fts MATCH ? ORDER BY rank LIMIT ?", (match, limit))
@@ -208,12 +261,13 @@ def search(con, query: str, limit: int = 20) -> list[dict]:
             arows = con.execute(
                 "SELECT 'file: ' || a.filename AS speaker, a.created_at, c.title, "
                 "c.external_id conversation_id, "
-                "snippet(attachments_fts, 0, '>>', '<<', ' … ', 24) AS content "
+                "snippet(attachments_fts, 0, '>>', '<<', ' … ', 24) AS content, "
+                "'' AS web_sources "
                 "FROM attachments_fts JOIN attachments a ON a.id = attachments_fts.rowid "
                 "JOIN conversations c ON c.id = a.conversation_id "
                 "WHERE attachments_fts MATCH ? ORDER BY rank LIMIT ?",
                 (match, limit - len(hits)))
             hits += [dict(r) for r in arows]
-        return hits
+        return _with_web_sources(hits)
     except Exception:
         return _like_fallback(con, words, limit)

--- a/memory_service/ledger.py
+++ b/memory_service/ledger.py
@@ -162,7 +162,8 @@ def add_fact(con, content: str, settings, *, source: str = "user",
         "content_hash, quarantined_at, quarantine_reason, person_id) "
         "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (content, source, origin, conversation_id, source_message_id, ts,
-         event_date or ts, confidence, importance, db.content_hash(content),
+         event_date if event_date is not None else db.day_start(ts),
+         confidence, importance, db.content_hash(content),
          ts if reason else None, reason, person_id))
     con.commit()
     _spawn_embed(settings, cur.lastrowid, content)

--- a/memory_service/mining.py
+++ b/memory_service/mining.py
@@ -15,7 +15,7 @@ import re
 import threading
 from datetime import datetime, timezone
 
-from . import captions, episodic, ledger, llm, persons, recall, summary, walls
+from . import captions, db, episodic, ledger, llm, persons, recall, summary, walls
 
 # Per-conversation distill locks. A distill run reads the conversation's
 # `mined_upto` watermark once, then mines everything after it. Two runs for the
@@ -76,15 +76,16 @@ def _grounded_event_date(model_date: str | None, source_text: str,
         datetime(year, month, day)
     except ValueError:
         return None
-    ref_year = datetime.fromtimestamp(ref_ts, tz=timezone.utc).year
+    ref_year = datetime.fromtimestamp(ref_ts).year
     for mo, dy, yr in _explicit_dates(source_text):
         # Grounded when the day/month match; if the text names a year it must
         # match too, otherwise the model's year is discarded for the ref year.
         if mo == month and dy == day and (yr is None or yr == year):
             final_year = yr if yr is not None else ref_year
             try:
-                return datetime(final_year, mo, dy,
-                                tzinfo=timezone.utc).timestamp()
+                # A calendar day at the owner's local midnight (contract
+                # 1.4, workbench#63), the same anchor every writer uses.
+                return datetime(final_year, mo, dy).timestamp()
             except ValueError:
                 return None
     return None
@@ -616,11 +617,11 @@ def _distill_chunk(con, settings, source_app: str, conv: dict,
             conv_ts = bound["created_at"]
             event_date = _grounded_event_date(
                 event.group(1) if event else None,
-                _msg_body(bound), conv_ts) or conv_ts
+                _msg_body(bound), conv_ts) or db.day_start(conv_ts)
             source_message_id = bound["id"]
         else:
             conv_ts = new_msgs[-1]["created_at"]
-            event_date = conv_ts            # no binding → conversation time, full stop
+            event_date = db.day_start(conv_ts)  # no binding → the conversation's day, full stop
             # ...and NO source message. The window's last turn used to be
             # recorded here as a stand-in, which read downstream (the admin
             # page's "source message #N", any reviewer following the trail) as

--- a/memory_service/recall.py
+++ b/memory_service/recall.py
@@ -67,7 +67,9 @@ def recall(con, settings, query: str = "", limit: int = 10,
         if sem > SEMANTIC_FLOOR or kw:
             e["_vec"] = ev  # reused by the dedup below; stripped in _out
             scored.append((score, e))
-    scored.sort(key=lambda x: -x[0])
+    # event_date is a calendar day (contract 1.4), so two facts about the
+    # same day score the same recency; the later save wins the tie.
+    scored.sort(key=lambda x: (-x[0], -(x[1].get("created_at") or 0)))
 
     # collapse exact (hash) + paraphrase (cosine) duplicates, keep highest-scored
     kept, kept_vecs, seen_hash = [], [], set()

--- a/tests/test_contract_1_4.py
+++ b/tests/test_contract_1_4.py
@@ -1,0 +1,176 @@
+"""Contract 1.4 (#84): the additive fields a client app consumes, and the
+calendar-day rule for event_date. Every one is additive on 1.3, so the
+older assertions in test_api_contract.py keep passing beside these."""
+
+import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import db, ledger, recall
+from memory_service.api import create_app
+
+
+def _client(settings):
+    app = create_app(settings)
+    return TestClient(app, base_url="http://127.0.0.1",
+                      headers={"Authorization": f"Bearer {app.state.admin_token}"})
+
+
+@pytest.fixture
+def client(settings, fake_llm):
+    return _client(settings)
+
+
+def _ingest(client, conv, msgs):
+    r = client.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": conv,
+        "title": "t", "messages": msgs})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _msg(ext, text, **extra):
+    return {"external_id": ext, "speaker": "user", "content": text,
+            "created_at": "2026-07-01T10:00:00+10:00", **extra}
+
+
+# ---- handshake ----
+
+def test_health_speaks_1_4_and_reports_loopback_origin_by_default(client, settings):
+    h = client.get("/v1/health").json()
+    assert h["contract_version"] == "1.4"
+    assert h["browser_origin"] == f"http://127.0.0.1:{settings.port}"
+
+
+def test_browser_origin_follows_the_trusted_tailnet_host(settings, fake_llm):
+    served = settings.model_copy(update={"trusted_hosts": ["mac.example.ts.net"]})
+    h = _client(served).get("/v1/health").json()
+    assert h["browser_origin"] == "https://mac.example.ts.net:8443"
+    custom = settings.model_copy(update={"trusted_hosts": ["mac.example.ts.net"],
+                                         "tailscale_port": 9443})
+    assert custom.reachable_browser_origin() == "https://mac.example.ts.net:9443"
+
+
+def test_browser_origin_explicit_setting_wins_and_loses_its_slash(settings):
+    explicit = settings.model_copy(update={"browser_origin": "https://memory.example.net/",
+                                           "trusted_hosts": ["other.host"]})
+    assert explicit.reachable_browser_origin() == "https://memory.example.net"
+
+
+# ---- search carries provenance back out ----
+
+def test_search_hits_carry_web_sources(client):
+    _ingest(client, "c-web", [
+        _msg("1", "the kakapo is a flightless parrot",
+             web_sources=["example.com", "birds.example.org"]),
+        _msg("2", "the kakapo lives in New Zealand"),
+    ])
+    hits = client.post("/v1/search", json={"query": "kakapo", "limit": 10}).json()["hits"]
+    by_content = {h["content"]: h for h in hits}
+    assert len(hits) == 2
+    for h in hits:
+        assert isinstance(h["web_sources"], list)
+    stamped = [h for h in hits if h["web_sources"]]
+    assert len(stamped) == 1
+    assert stamped[0]["web_sources"] == ["example.com", "birds.example.org"]
+    assert [h for h in hits if not h["web_sources"]][0]["web_sources"] == []
+
+
+def test_like_fallback_hits_carry_web_sources(con, settings):
+    from memory_service import episodic
+    episodic.ingest(con, "multi-model-chat", "c-fb", [
+        {"external_id": "1", "speaker": "user", "content": "weka on the track",
+         "created_at": 1700000000.0, "web_sources": ["example.com"]}])
+    con.commit()
+    hits = episodic._like_fallback(con, ["weka"], 5)
+    assert hits and hits[0]["web_sources"] == ["example.com"]
+
+
+# ---- the per-conversation watermark ----
+
+def test_watermark_unknown_conversation_is_404_in_the_envelope(client):
+    r = client.get("/v1/conversations/multi-model-chat/nope/watermark")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "404"
+
+
+def test_watermark_reports_the_numerically_highest_id(client):
+    _ingest(client, "c-wm", [_msg("9", "nine"), _msg("10", "ten")])
+    r = client.get("/v1/conversations/multi-model-chat/c-wm/watermark")
+    assert r.status_code == 200
+    assert r.json() == {"highest_external_id": "10", "messages": 2}
+
+
+def test_watermark_is_open_on_loopback_without_the_owner_token(settings, fake_llm):
+    app = create_app(settings)
+    anon = TestClient(app, base_url="http://127.0.0.1")
+    anon.post("/v1/ingest", json={
+        "source_app": "multi-model-chat", "conversation_id": "c-open",
+        "messages": [_msg("3", "three")]})
+    r = anon.get("/v1/conversations/multi-model-chat/c-open/watermark")
+    assert r.status_code == 200
+    assert r.json()["highest_external_id"] == "3"
+
+
+def test_watermark_counts_an_erased_message_as_held(client):
+    """The owner erased the newest message. The watermark must not drop
+    below it, or the client would re-send the exact message just erased."""
+    _ingest(client, "c-er", [_msg("20", "keep this"), _msg("21", "erase this")])
+    ref = client.get("/v1/messages/resolve", params={
+        "source_app": "multi-model-chat", "conversation": "c-er", "message": "21"})
+    assert ref.status_code == 200, ref.text
+    mid = ref.json()["id"]
+    assert client.delete(f"/v1/messages/{mid}").status_code == 200
+    r = client.get("/v1/conversations/multi-model-chat/c-er/watermark").json()
+    assert r == {"highest_external_id": "21", "messages": 1}
+
+
+# ---- event_date is a calendar day ----
+
+def _local_midnight(y, m, d):
+    return datetime.datetime(y, m, d).timestamp()
+
+
+def _stored(client, fact_id):
+    facts = client.get("/v1/facts", params={"status": "all", "limit": 1000}).json()["facts"]
+    return next(f for f in facts if f["id"] == fact_id)
+
+
+def test_saved_fact_event_date_is_local_midnight_of_its_day(client):
+    r = client.post("/v1/facts", json={"content": "signed the lease on the fourth",
+                                       "event_date": "2026-07-04"})
+    assert r.status_code == 200, r.text
+    assert _stored(client, r.json()["id"])["event_date"] == _local_midnight(2026, 7, 4)
+
+
+def test_saved_fact_timestamp_collapses_to_its_local_day(client):
+    noon_local = datetime.datetime(2026, 7, 4, 12, 0).astimezone().isoformat()
+    r = client.post("/v1/facts", json={"content": "lunch meeting about the lease",
+                                       "event_date": noon_local})
+    assert _stored(client, r.json()["id"])["event_date"] == _local_midnight(2026, 7, 4)
+
+
+def test_fact_without_event_date_gets_the_day_it_was_saved(con, settings):
+    added = ledger.add_fact(con, "a fact saved just now", settings)
+    f = dict(con.execute("SELECT event_date, created_at FROM facts WHERE id=?",
+                         (added["id"],)).fetchone())
+    assert f["event_date"] == db.day_start(f["created_at"])
+    assert f["event_date"] <= f["created_at"] < f["event_date"] + 86400
+
+
+def test_day_start_is_idempotent_and_local():
+    ts = datetime.datetime(2026, 7, 4, 23, 59, 59).timestamp()
+    assert db.day_start(ts) == _local_midnight(2026, 7, 4)
+    assert db.day_start(db.day_start(ts)) == db.day_start(ts)
+
+
+def test_recall_breaks_a_same_day_tie_on_the_save_time(con, settings):
+    day = _local_midnight(2026, 7, 4)
+    older = ledger.add_fact(con, "kea parrot sighting one", settings, event_date=day)
+    newer = ledger.add_fact(con, "kea parrot sighting two", settings, event_date=day)
+    con.execute("UPDATE facts SET created_at=? WHERE id=?", (day + 100, older["id"]))
+    con.execute("UPDATE facts SET created_at=? WHERE id=?", (day + 200, newer["id"]))
+    con.commit()
+    got = recall.recall(con, settings, "kea parrot sighting", limit=5)
+    assert [g["id"] for g in got][:2] == [newer["id"], older["id"]]

--- a/tests/test_identity_wire.py
+++ b/tests/test_identity_wire.py
@@ -128,6 +128,8 @@ def test_a_merged_slug_binds_to_the_winner_and_forgotten_binds_nothing(
     assert _fact_from(client, settings, "g2")["person_id"] is None
 
 
-def test_health_announces_contract_1_3(client):
-    # 1.3 (#55) is additive over 1.2: web_sources on ingest and facts.
-    assert client.get("/v1/health").json()["contract_version"] == "1.3"
+def test_health_announces_a_contract_that_still_carries_1_3(client):
+    # 1.3 (#55) is additive over 1.2, and 1.4 (#84) over 1.3: the version
+    # only ever moves up, and a client gating on the major keeps working.
+    major, minor = client.get("/v1/health").json()["contract_version"].split(".")
+    assert (int(major), int(minor)) >= (1, 3)

--- a/tests/test_mining.py
+++ b/tests/test_mining.py
@@ -1,6 +1,11 @@
 """The reflection pass — strict NEW: parsing, walls applied, watermark advances."""
 
-from memory_service import episodic, ledger, mining
+from memory_service import db, episodic, ledger, mining
+
+
+def _day(ts):
+    """event_date is a calendar day at local midnight (contract 1.4)."""
+    return db.day_start(ts)
 
 
 def test_distill_mines_and_grounds(con, settings, sample_conversation, fake_llm):
@@ -18,7 +23,7 @@ def test_distill_mines_and_grounds(con, settings, sample_conversation, fake_llm)
     clean = ledger.list_facts(con, status="valid")
     assert len(clean) == 1 and "Initech" in clean[0]["content"]
     assert clean[0]["origin_agent"] == "multi-model-chat"
-    assert clean[0]["event_date"] == 1700000060.0  # dated to the conversation
+    assert clean[0]["event_date"] == _day(1700000060.0)  # dated to the conversation
 
 
 def test_distill_supersedes_listed_entry(con, settings, sample_conversation, fake_llm):
@@ -116,7 +121,7 @@ from datetime import datetime, timezone
 
 
 def _epoch(y, m, d):
-    return datetime(y, m, d, tzinfo=timezone.utc).timestamp()
+    return datetime(y, m, d).timestamp()  # local midnight, the 1.4 anchor
 
 
 def _ingest_one(con, text, ts=1700000060.0):
@@ -153,7 +158,7 @@ def test_vague_retrospective_stays_at_conversation_time(con, settings, fake_llm)
     fake_llm["response"] = "NEW importance=3: The recruiter thread had cooled and gone quiet."
     mining.distill(con, settings, "multi-model-chat", "chat-d", regenerate=False)
     fact = ledger.list_facts(con, status="valid")[0]
-    assert fact["event_date"] == 1700000060.0          # unchanged
+    assert fact["event_date"] == _day(1700000060.0)          # unchanged
 
 
 def test_live_present_tense_unchanged(con, settings, fake_llm):
@@ -161,7 +166,7 @@ def test_live_present_tense_unchanged(con, settings, fake_llm):
     fake_llm["response"] = "NEW importance=6: Alex is a data engineer at Initech."
     mining.distill(con, settings, "multi-model-chat", "chat-d", regenerate=False)
     fact = ledger.list_facts(con, status="valid")[0]
-    assert fact["event_date"] == 1700000060.0
+    assert fact["event_date"] == _day(1700000060.0)
 
 
 def test_hallucinated_date_not_grounded_is_ignored(con, settings, fake_llm):
@@ -171,7 +176,7 @@ def test_hallucinated_date_not_grounded_is_ignored(con, settings, fake_llm):
     fake_llm["response"] = "NEW src=1 event=2023-10-01 importance=3: The recruiter thread had cooled."
     mining.distill(con, settings, "multi-model-chat", "chat-d", regenerate=False)
     fact = ledger.list_facts(con, status="valid")[0]
-    assert fact["event_date"] == 1700000060.0          # invented date ignored
+    assert fact["event_date"] == _day(1700000060.0)          # invented date ignored
 
 
 # --- Binding a fact to its source message before grounding ----------
@@ -202,7 +207,7 @@ def test_date_in_other_message_is_rejected(con, settings, fake_llm):
     fake_llm["response"] = "NEW src=2 event=2023-06-30 importance=5: Alex's office move is sorted."
     mining.distill(con, settings, "multi-model-chat", "chat-m", regenerate=False)
     fact = ledger.list_facts(con, status="valid")[0]
-    assert fact["event_date"] == 1700000100.0          # bound msg's time, not June 30
+    assert fact["event_date"] == _day(1700000100.0)          # bound msg's time, not June 30
 
 
 def test_date_in_bound_message_is_accepted(con, settings, fake_llm):
@@ -228,7 +233,7 @@ def test_invalid_src_falls_back_to_conversation_time(con, settings, fake_llm):
     fake_llm["response"] = "NEW src=99 event=2023-06-30 importance=5: The project kickoff is set for 2023-06-30."
     mining.distill(con, settings, "multi-model-chat", "chat-m", regenerate=False)
     fact = ledger.list_facts(con, status="valid")[0]
-    assert fact["event_date"] == 1700000100.0          # conversation time, not June 30
+    assert fact["event_date"] == _day(1700000100.0)          # conversation time, not June 30
 
 
 def test_missing_src_falls_back_to_conversation_time(con, settings, fake_llm):
@@ -241,7 +246,7 @@ def test_missing_src_falls_back_to_conversation_time(con, settings, fake_llm):
     fake_llm["response"] = "NEW event=2023-06-30 importance=5: The project kickoff is set for 2023-06-30."
     mining.distill(con, settings, "multi-model-chat", "chat-m", regenerate=False)
     fact = ledger.list_facts(con, status="valid")[0]
-    assert fact["event_date"] == 1700000100.0          # conversation time, not June 30
+    assert fact["event_date"] == _day(1700000100.0)          # conversation time, not June 30
 
 
 def test_bound_message_sets_source_message_id(con, settings, fake_llm):
@@ -306,7 +311,7 @@ def test_source_qualifier_kept_verbatim_passes_clean(con, settings, fake_llm):
                          regenerate=False)
     assert res["added"] == 1 and res["quarantined"] == 0
     fact = ledger.list_facts(con, status="valid")[0]
-    assert fact["event_date"] == 1700000060.0   # conversation time, not resolved
+    assert fact["event_date"] == _day(1700000060.0)   # conversation time, not resolved
 
 
 # --- importance is REQUIRED: retry once, then quarantine -------------
@@ -405,7 +410,7 @@ def test_backdated_fact_cannot_supersede_newer(con, settings, fake_llm):
     valid = ledger.list_facts(con, status="valid")
     assert any(f["id"] == current["id"] for f in valid)  # newer fact survives
     mined = [f for f in valid if "Globex" in f["content"]]
-    assert mined and mined[0]["event_date"] == 1700000100.0
+    assert mined and mined[0]["event_date"] == _day(1700000100.0)
 
 
 def test_quarantined_fact_defers_supersession(con, settings, fake_llm):


### PR DESCRIPTION
Membro is the fleet's memory home. Crossband hands it chats and reads memory back over a versioned HTTP contract, until now 1.3. This PR moves it to 1.4 with four additive changes, so one deploy here unlocks four fixes on the crossband side (crossband#318).

What changes for the person using the apps, once crossband consumes it:

- Web text a model read in a past chat comes back out of the archive marked untrusted, the same as a live fetch. Today the marking is stored but dropped on the way out.
- The voice-discard banner's link to the eraser works from a phone, because this service now says where a browser can reach it instead of crossband guessing a port.
- Restoring membro from a snapshot no longer leaves a permanent silent hole in the ledger. Crossband can ask how far this record reaches and wind its own watermark back.
- A fact's event date means one thing everywhere: the calendar day, at the owner's local midnight. Two facts about the same day now sort by when they were saved.

Risk of acting: the date change touches every writer and the recall order, so it carries tests for each writer and the tiebreak. The watermark route is content-free and open on loopback like /health. Everything else is an added field. Risk of leaving: four shipped promises stay untrue and invisible.

Prompted by: the 2026-09-02 backlog review, first build wave chosen by the owner. Closes #84 and, with crossband#318, workbench#60, #63, #64 and #68.

Deploy order: this first, then crossband#318. A 1.3 crossband against this service sees nothing new and keeps working.

## Detail

- `/v1/search` hits carry `web_sources` (`episodic.search`, `_like_fallback`, new `_with_web_sources`); attachment hits carry an empty list.
- `/v1/health` carries `browser_origin` (`Settings.reachable_browser_origin`): the `browser_origin` setting or `MEMORY_BROWSER_ORIGIN` when set, else `https://<first trusted host>:<tailscale_port>`, else loopback. New `tailscale_port` setting and `MEMORY_TAILSCALE_PORT` env, defaulting to the serve script's 8443.
- New `GET /v1/conversations/{source_app}/{conversation_id}/watermark` (`episodic.watermark`): highest external id, compared numerically when every id is an integer string. Erased messages count as held, read back from the erasure journal's `ref:` segment, so a client cannot wind back past an erasure and re-send it. 404 in the standard envelope when unknown.
- `event_date`: new `db.day_start` is the one anchor. `api._event_day` applies it on `POST` and `PATCH /v1/facts`; `mining._grounded_event_date` and both conversation-time fallbacks use it; `ledger.add_fact` dates an undated save to its day. `recall` sorts on `(score, created_at)`.
- `contract_version` is "1.4"; `docs/API.md` gains the 1.4 rule, the health field, the search field and the watermark route; `changelog.d/84-contract-1-4.md`.
- Tests: `tests/test_contract_1_4.py` (15 new), mining tests moved to the local-midnight anchor, the health version pin now checks the version only moves up. 495 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
