### PR TITLE
Contract 1.5: a model's direct save carries guest presence, and membro holds it

### DIFF
--- a/changelog.d/93-contract-1-5.md
+++ b/changelog.d/93-contract-1-5.md
@@ -1,0 +1,9 @@
+- Memory contract 1.5 (#93): a model's direct save now says who was in
+  the room. `POST /facts` may carry `guest_speakers`, the same
+  `guest:<name>` and `guest:unknown` values `/ingest` uses, and a stamped
+  save is held for review under a new group, "Saved while a guest was
+  in the room". The mined path already held a guest's words because
+  each message names its speaker; the save tool named nobody, so a
+  guest's claim relayed by a model reached canon unheld. A save that
+  also read the web keeps its web-derived group with the guest clause
+  appended. A 1.4 client keeps working unchanged.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# Memory Service API: the HTTP contract, v1.4
+# Memory Service API: the HTTP contract, v1.5
 
 The contract between Membro and its clients. Owned by this repo.
 Versioned; breaking changes bump the major version. Clients check `contract_version`
@@ -10,6 +10,15 @@ repo's CI (against the real service) and in each client's CI (against the stub).
 - Base URL: `http://127.0.0.1:8901/v1`
 - Local-only: the server refuses to bind a non-loopback address unless
   `MEMORY_AUTH_TOKEN` is set (then: `Authorization: Bearer <token>`).
+- **1.5 (#93): saves on `POST /facts` may carry `guest_speakers`**: the
+  guests in the room when a model saved the fact, as the speaker-class
+  values `/ingest` already uses (`guest:<name>`, `guest:unknown`; a list of
+  strings, max 12). A stamped save is quarantined with a `guest-present:`
+  reason naming the guests. The mined path already holds a guest's words
+  because each message names its speaker; this closes the same wall over
+  the direct save. The origin trust gate outranks the stamp, and a save
+  carrying both stamps keeps its `web-derived:` reason with the guest
+  clause appended. Absent field = exactly the 1.4 behaviour.
 - **1.4 (#84): four additive fields for a client that reads memory
   back.** `/search` hits carry `web_sources`. `/health` carries
   `browser_origin`. `GET /conversations/{app}/{id}/watermark` reports the
@@ -90,7 +99,7 @@ at the end of it.
 ```json
 {
   "status": "ok|degraded",
-  "contract_version": "1.4",
+  "contract_version": "1.5",
   "browser_origin": "http://127.0.0.1:8901",
   "db": {"facts": 0, "messages": 0, "size_bytes": 0, "integrity": "ok",
           "fts_in_sync": true, "last_backup_at": null},
@@ -435,7 +444,9 @@ service has less, which is what a restore from a snapshot leaves behind.
 ```json
 {"content": "...", "event_date": "2026-07-04", "confidence": "high|medium|low",
  "origin_agent": "user | <participant-slug> | mcp:<client>",
- "source_app": "<registered app>"}
+ "source_app": "<registered app>",
+ "web_sources": ["<domain>", "..."],
+ "guest_speakers": ["guest:<name>", "guest:unknown"]}
 ```
 `content` is whitespace-collapsed first, then must be 8–10 000 characters;
 anything shorter or longer is a 422 ("nothing meaningful to save" / "fact too
@@ -447,6 +458,22 @@ time. Omit it and the fact is dated to the day it was saved, which is
 how invariant 5 holds (`event_date` is never null).
 `source_app` is what the gate reads below; `confidence` defaults to `high`
 and `origin_agent` to `user`.
+
+`web_sources` (1.3) and `guest_speakers` (1.5) are optional stamps, both
+defaulting to empty. `web_sources` lists the web domains read in the
+round that produced the save (max 20). `guest_speakers` lists the guests
+in the room when a model made the save, as `/ingest` speaker values (max
+12): `guest:<name>` for one confidently identified human besides the
+owner, or `guest:unknown` for a human who could not be identified. Both
+are normalised the same way: entries are stripped, empties dropped,
+duplicates removed, order kept. A `guest_speakers` entry that is not a
+guest class (a model slug, `user`, an unknown prefix) is dropped, not
+rejected. A save carrying either stamp is held for review: `web-derived:`
+names the domains, `guest-present:` names the guests in plain English
+(`guest:unknown` reads as "an unidentified guest"; at most five are
+named). When both are present the reason keeps the `web-derived:` prefix
+and the guest clause follows after `; `. The origin gate below outranks
+both stamps.
 
 Gate (invariant 4; the gate applies to the write itself, whoever the writer
 is): a write reaches canon only if `origin_agent` is `user` **or** it
@@ -536,7 +563,8 @@ reviewer has, who said this, is answered without leaving the queue.
 ```
 Each row also carries `reason_class` (additive, 2026-08-14, #34): a stable
 token derived from the hold reason's prefix (`guest-attribution`,
-`speaker-trust`, `grounding`, `temporal`, `source-trust`, `importance`,
+`guest-present`, `speaker-trust`, `grounding`, `temporal`, `source-trust`,
+`source-trust-judged`, `source-deleted`, `importance`, `web-derived`,
 `external-write`, else `other`; a multi-flag reason classes by its first
 flag). The admin page groups the queue by it, and
 `POST /facts/bulk-approve` / `POST /facts/bulk-dismiss` (owner credential,

--- a/memory_service/api.py
+++ b/memory_service/api.py
@@ -136,6 +136,12 @@ class FactBody(BaseModel):
     # that read the web, so the fact is held (the miner cannot be bypassed by
     # an explicit save).
     web_sources: list[str] = Field([], max_length=20)
+    # additive, contract 1.5 (#93): the guests in the room when a model saved
+    # this, as the speaker-class values /ingest already carries
+    # (`guest:<name>`, `guest:unknown`). Non-empty = held as guest-present,
+    # so the guest wall covers the direct save as well as the mined path.
+    # Absent = exactly the 1.4 behaviour.
+    guest_speakers: list[str] = Field([], max_length=12)
 
 
 class FactPatch(BaseModel):
@@ -1148,7 +1154,7 @@ terminal at startup, or your <code>MEMORY_AUTH_TOKEN</code>.</small></p>
                 body.origin_agent != "user" else "user",
                 origin_agent=body.origin_agent, source_app=body.source_app,
                 event_date=_event_day(body.event_date), confidence=body.confidence,
-                web_sources=body.web_sources)
+                web_sources=body.web_sources, guest_speakers=body.guest_speakers)
         except ValueError as e:
             raise HTTPException(422, str(e))
         finally:

--- a/memory_service/config.py
+++ b/memory_service/config.py
@@ -71,10 +71,11 @@ class Settings(BaseModel):
     trusted_apps: list[str] = []  # register your own client app slugs; empty = no app-trusted writes
     grounding_allowlist: list[str] = []    # user-specific ubiquitous nouns, config not code
 
+    # 1.5 (#93): guest_speakers on POST /facts, held as guest-present.
     # 1.4 (#84): web_sources on /search hits, browser_origin on /health, the
     # per-conversation watermark route, event_date as a calendar day.
     # 1.3 (#55): web_sources on ingest + facts. 1.2 (#33): speaker_identity.
-    contract_version: str = "1.4"
+    contract_version: str = "1.5"
     # The origin a browser on a phone can reach this service at, reported on
     # /v1/health as `browser_origin` (contract 1.4) so a client app links the
     # admin surface at an address that works instead of guessing a port.

--- a/memory_service/ledger.py
+++ b/memory_service/ledger.py
@@ -10,7 +10,7 @@ import logging
 import re
 import threading
 
-from . import db
+from . import db, walls
 
 log = logging.getLogger("memory_service.ledger")
 
@@ -85,6 +85,7 @@ def add_fact(con, content: str, settings, *, source: str = "user",
              source_message_id: int | None = None,
              quarantine_reason: str | None = None,
              web_sources: list[str] | None = None,
+             guest_speakers: list[str] | None = None,
              dedupe_in_conversation: bool = False) -> dict:
     """Append one fact. Untrusted origins are quarantined at creation (the gate);
     a caller-supplied quarantine_reason (e.g. a wall flag) also quarantines.
@@ -94,6 +95,15 @@ def add_fact(con, content: str, settings, *, source: str = "user",
     from the source message's stamp on the mining path. Non-empty means the
     fact is held with a `web-derived:` reason: a public page must not write
     memory by phrasing a sentence well. The origin gate outranks it.
+
+    `guest_speakers` (#93, contract 1.5): the guests in the room when a model
+    saved this directly, as `/ingest` speaker-class values (`guest:<name>`,
+    `guest:unknown`). The mined path already holds a guest's words because
+    each message names its speaker; a direct save named nobody, so a guest's
+    claim relayed by a model reached canon unheld. Non-empty means the fact
+    is held with a `guest-present:` reason. The origin gate outranks it, and
+    when a web stamp is also present web-derived keeps the reason slot with
+    the guest clause appended, so the review class stays web-derived.
 
     `dedupe_in_conversation` is a NARROW write-time guard for the mining path
 : when set, re-adding a fact whose normalized content already exists
@@ -156,6 +166,20 @@ def add_fact(con, content: str, settings, *, source: str = "user",
         shown = ", ".join(sorted(set(webs))[:5])[:300]
         reason = (f"web-derived: {shown} — a public page was read in this "
                   "round; held for review before becoming canon")
+    guests = _guest_list(guest_speakers)
+    if guests:
+        who = _render_guests(guests)
+        verb = "was" if len(guests) == 1 else "were"
+        clause = (f"guest-present: {who} {verb} in the room when a model "
+                  "saved this; held for review before it becomes canon")
+        if reason is None:
+            reason = clause
+        elif reason.startswith("web-derived:"):
+            # Both stamps on one save: web-derived claimed the slot first,
+            # and reason_class() reads the first flag, so the queue keeps
+            # grouping it under the web page. The guest clause still rides
+            # the row for the reviewer.
+            reason = f"{reason}; {clause}"
     cur = con.execute(
         "INSERT INTO facts(content, source, origin_agent, conversation_id, "
         "source_message_id, created_at, event_date, confidence, importance, "
@@ -168,6 +192,32 @@ def add_fact(con, content: str, settings, *, source: str = "user",
     con.commit()
     _spawn_embed(settings, cur.lastrowid, content)
     return {"id": cur.lastrowid, "quarantined": bool(reason)}
+
+
+def _guest_list(guest_speakers) -> list[str]:
+    """Normalise a `guest_speakers` stamp the way web_sources is: strip, drop
+    empties, dedupe, keep order. Anything that is not a guest class (a model
+    slug, `user`, an unknown prefix) is dropped rather than rejected: the
+    field is a presence stamp, and a client that sends the wrong shape has
+    not made a claim this ledger can hold on."""
+    out: list[str] = []
+    for g in guest_speakers or []:
+        g = str(g).strip()
+        if walls.speaker_class(g) not in ("guest", "guest-unknown"):
+            continue
+        if g not in out:
+            out.append(g)
+    return out
+
+
+def _render_guests(guests: list[str]) -> str:
+    """Plain English for the hold reason: names from `guest:<name>`, and
+    `guest:unknown` as an unidentified guest. Capped like the web-derived
+    reason (five entries, 300 characters) so one save cannot pad a row."""
+    names = [walls.guest_name(g) or "an unidentified guest" for g in guests[:5]]
+    if len(names) == 1:
+        return names[0][:300]
+    return (", ".join(names[:-1]) + " and " + names[-1])[:300]
 
 
 def list_facts(con, status: str = "valid", query: str | None = None,

--- a/memory_service/static/index.html
+++ b/memory_service/static/index.html
@@ -863,6 +863,7 @@ const REASON_CLASS_COPY = {
   "importance": "Low importance",
   "external-write": "Written by external tooling",
   "web-derived": "Learnt from a web page",
+  "guest-present": "Saved while a guest was in the room",
   "other": "Other holds",
 };
 

--- a/tests/test_contract_1_4.py
+++ b/tests/test_contract_1_4.py
@@ -37,9 +37,11 @@ def _msg(ext, text, **extra):
 
 # ---- handshake ----
 
-def test_health_speaks_1_4_and_reports_loopback_origin_by_default(client, settings):
+def test_health_speaks_at_least_1_4_and_reports_loopback_origin_by_default(client, settings):
     h = client.get("/v1/health").json()
-    assert h["contract_version"] == "1.4"
+    # 1.5 (#93) is additive over 1.4: the version only ever moves up.
+    major, minor = h["contract_version"].split(".")
+    assert (int(major), int(minor)) >= (1, 4)
     assert h["browser_origin"] == f"http://127.0.0.1:{settings.port}"
 
 

--- a/tests/test_contract_1_5.py
+++ b/tests/test_contract_1_5.py
@@ -1,0 +1,109 @@
+"""Contract 1.5 (#93): `guest_speakers` on POST /facts. Additive on 1.4, so
+the older assertions in test_contract_1_4.py keep passing beside these."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import db as db_mod
+from memory_service import ledger
+from memory_service.api import create_app, reason_class
+
+
+@pytest.fixture
+def client(settings, fake_llm):
+    app = create_app(settings)
+    return TestClient(app, base_url="http://127.0.0.1",
+                      headers={"Authorization": f"Bearer {app.state.admin_token}"})
+
+
+def _reason(settings, fact_id):
+    c = db_mod.connect(settings.db_path)
+    try:
+        return c.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                         (fact_id,)).fetchone()[0]
+    finally:
+        c.close()
+
+
+def _post(client, **extra):
+    body = {"content": "the workshop's bandsaw blade wants replacing",
+            "origin_agent": "claude-x", "source_app": "multi-model-chat"}
+    body.update(extra)
+    return client.post("/v1/facts", json=body)
+
+
+# ---- handshake ----
+
+def test_health_speaks_1_5(client):
+    assert client.get("/v1/health").json()["contract_version"] == "1.5"
+
+
+# ---- the field ----
+
+def test_stamped_save_is_accepted_and_held(client, settings):
+    r = _post(client, guest_speakers=["guest:Alex"])
+    assert r.status_code == 200, r.text
+    assert r.json()["quarantined"] is True
+    assert reason_class(_reason(settings, r.json()["id"])) == "guest-present"
+
+
+def test_body_without_the_field_is_the_1_4_behaviour(client):
+    r = _post(client)
+    assert r.status_code == 200, r.text
+    assert r.json() == {"id": r.json()["id"], "quarantined": False}
+
+
+def test_unknown_shapes_are_dropped_not_rejected(client):
+    # A model slug, the owner, an empty string, and a class this build does
+    # not know: none of them is a guest, so none of them holds the save.
+    r = _post(client, guest_speakers=["claude-x", "user", "  ", "visitor:Alex"])
+    assert r.status_code == 200, r.text
+    assert r.json()["quarantined"] is False
+
+
+def test_unknown_shapes_beside_a_real_guest_still_hold(client, settings):
+    r = _post(client, guest_speakers=["visitor:Sam", "guest:Alex"])
+    assert r.json()["quarantined"] is True
+    reason = _reason(settings, r.json()["id"])
+    assert "Alex" in reason and "Sam" not in reason
+
+
+def test_entries_are_stripped_and_deduped_in_order(client, settings):
+    r = _post(client, guest_speakers=[" guest:Sam ", "guest:Alex", "guest:Sam", ""])
+    reason = _reason(settings, r.json()["id"])
+    assert reason.startswith("guest-present: Sam and Alex were ")
+
+
+def test_cap_is_twelve_entries(client):
+    twelve = [f"guest:Guest{i}" for i in range(12)]
+    assert _post(client, guest_speakers=twelve).status_code == 200
+    assert _post(client, guest_speakers=twelve + ["guest:Extra"]).status_code == 422
+
+
+def test_reason_names_at_most_five_guests(settings, con):
+    res = ledger.add_fact(con, "a save made in a crowded room", settings,
+                          origin_agent="claude-x", source_app="multi-model-chat",
+                          guest_speakers=[f"guest:Guest{i}" for i in range(8)])
+    reason = con.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                         (res["id"],)).fetchone()[0]
+    assert "Guest4" in reason and "Guest5" not in reason
+
+
+def test_reason_is_capped_at_300_characters(settings, con):
+    long_name = "guest:" + "A" * 400
+    res = ledger.add_fact(con, "a save with an absurdly long guest name", settings,
+                          origin_agent="claude-x", source_app="multi-model-chat",
+                          guest_speakers=[long_name])
+    reason = con.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                         (res["id"],)).fetchone()[0]
+    assert reason.startswith("guest-present: " + "A" * 300 + " was in the room")
+    assert "A" * 301 not in reason
+
+
+def test_review_row_carries_the_new_class(client):
+    r = _post(client, guest_speakers=["guest:unknown"])
+    rows = client.get("/v1/review").json()["facts"]
+    row = next(x for x in rows if x["id"] == r.json()["id"])
+    assert row["reason_class"] == "guest-present"
+    assert row["quarantine_reason"].startswith(
+        "guest-present: an unidentified guest was in the room")

--- a/tests/test_guest_present_hold.py
+++ b/tests/test_guest_present_hold.py
@@ -1,0 +1,110 @@
+"""Guest-present hold (#93, contract 1.5): a fact a model saved directly while
+a guest was in the room is held for review. The mined path already holds a
+guest's words because each ingested message names its speaker; the direct
+save named nobody, so a guest's claim relayed by a model reached canon
+unheld. The stamp rides /v1/facts like web_sources does, and the ledger
+applies the hold at the same choke point."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory_service import db as db_mod
+from memory_service import ledger, recall, summary
+from memory_service.api import create_app, reason_class
+
+
+@pytest.fixture
+def client(settings, fake_llm):
+    app = create_app(settings)
+    return TestClient(app, base_url="http://127.0.0.1",
+                      headers={"Authorization": f"Bearer {app.state.admin_token}"})
+
+
+def _reason(settings, fact_id):
+    c = db_mod.connect(settings.db_path)
+    try:
+        return c.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                         (fact_id,)).fetchone()[0]
+    finally:
+        c.close()
+
+
+def _save(client, **extra):
+    body = {"content": "the fence along the back lane needs a new post",
+            "origin_agent": "claude-x", "source_app": "multi-model-chat"}
+    body.update(extra)
+    r = client.post("/v1/facts", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_explicit_save_with_stamp_is_held_as_guest_present(client, settings):
+    res = _save(client, guest_speakers=["guest:Alex"])
+    assert res["quarantined"] is True
+    reason = _reason(settings, res["id"])
+    assert reason == ("guest-present: Alex was in the room when a model saved "
+                      "this; held for review before it becomes canon")
+    assert reason_class(reason) == "guest-present"
+
+
+def test_explicit_save_without_stamp_stays_trusted(client):
+    assert _save(client)["quarantined"] is False
+    assert _save(client, content="an empty stamp is no stamp at all",
+                 guest_speakers=[])["quarantined"] is False
+
+
+def test_unknown_guest_reads_as_unidentified(client, settings):
+    res = _save(client, guest_speakers=["guest:Alex", "guest:unknown"])
+    reason = _reason(settings, res["id"])
+    assert reason.startswith("guest-present: Alex and an unidentified guest were ")
+
+
+def test_origin_gate_outranks_the_guest_stamp(settings, con):
+    res = ledger.add_fact(
+        con, "a claim from an app nobody registered", settings,
+        source="model", origin_agent="stranger", source_app="unknown-app",
+        guest_speakers=["guest:Alex"])
+    assert res["quarantined"] is True
+    reason = con.execute("SELECT quarantine_reason FROM facts WHERE id=?",
+                         (res["id"],)).fetchone()[0]
+    assert reason.startswith("external write")  # the stronger gate names it
+    assert "guest-present" not in reason
+
+
+def test_web_stamp_keeps_the_slot_and_the_guest_clause_follows(client, settings):
+    res = _save(client, web_sources=["docs.example"], guest_speakers=["guest:Alex"])
+    assert res["quarantined"] is True
+    reason = _reason(settings, res["id"])
+    assert reason.startswith("web-derived: docs.example")
+    assert "; guest-present: Alex was in the room" in reason
+    assert reason_class(reason) == "web-derived"
+
+
+def test_the_owner_saving_by_hand_is_still_held_when_stamped(settings, con):
+    # The stamp says who was in the room, not who typed. A registered app
+    # that stamps an owner-origin save has said a guest was present, and
+    # the hold is about what the fact may have come from.
+    res = ledger.add_fact(con, "the owner typed this with a guest present",
+                          settings, guest_speakers=["guest:Sam"])
+    assert res["quarantined"] is True
+
+
+def test_held_guest_present_fact_never_reaches_recall_or_summary(con, settings, fake_llm):
+    ledger.add_fact(con, "Alex enjoys hiking in the mountains.", settings)
+    q = ledger.add_fact(con, "Alex secretly lives in Atlantis.", settings,
+                        origin_agent="claude-x", source_app="multi-model-chat",
+                        guest_speakers=["guest:Sam"])
+    assert q["quarantined"] is True
+    hits = recall.recall(con, settings, "Atlantis lives")
+    assert all(f["id"] != q["id"] for f in hits)
+    fake_llm["response"] = "profile text"
+    summary.regenerate(con, settings)
+    assert q["id"] not in summary.get(con)["source_fact_ids"]
+
+
+def test_approving_the_held_fact_releases_it(client, settings):
+    res = _save(client, guest_speakers=["guest:Alex"])
+    fid = res["id"]
+    assert client.post(f"/v1/facts/{fid}/approve").status_code == 200
+    valid = client.get("/v1/facts", params={"status": "valid"}).json()["facts"]
+    assert any(f["id"] == fid for f in valid)

--- a/tests/test_review_grouping.py
+++ b/tests/test_review_grouping.py
@@ -26,6 +26,12 @@ def test_reason_class_truth_table():
     # multi-flag reasons: the first flag is the class
     assert reason_class("speaker-trust: x; grounding: y — review before trusting") == "speaker-trust"
     assert reason_class("external write (mcp:tool) — held for review") == "external-write"
+    # 1.5 (#93): a stamped direct save; with a web stamp too, web-derived
+    # claimed the slot first and the guest clause rides after it
+    assert reason_class("guest-present: Alex was in the room when a model saved this; "
+                        "held for review") == "guest-present"
+    assert reason_class("web-derived: docs.example — a public page was read; "
+                        "guest-present: Alex was in the room") == "web-derived"
     assert reason_class("free-text with no prefix at all") == "other"
     assert reason_class("") == "other"
     assert reason_class(None) == "other"


### PR DESCRIPTION
Membro is the fleet's memory home. Crossband writes to it two ways: whole chats handed over for mining, and a model's direct save. The mined path holds a guest's words for review because each message names its speaker. The direct save carried the authoring model and the round's web stamp, but nothing about who was in the room, so in room mode a guest's claim relayed by a model reached canon unheld. This PR moves the contract to 1.5 with one additive field that closes the same wall over the direct save.

What changes for the person using the apps, once crossband stamps its saves (built against this contract at the same time):

- A fact a model saved while a guest was in the room now waits in the review queue under a new group, "Saved while a guest was in the room", with the guests named in plain English.
- One decision on the group clears it, the same as every other hold group.
- A save that also read the web keeps its "Learnt from a web page" group; the guest clause rides the row for the reviewer.

Risk of acting: one more additive field and one more hold group. A save the owner asked for with guests present now waits in review. Risk of leaving: any guest's claim can reach canon through a model's save, and room mode makes that routine.

Prompted by: the 2026-08-28 cross-app audit, and the owner's decision of 2026-08-30 on [workbench#65](https://github.com/shawn-durrani/workbench/issues/65) to stamp the save the way web sources are stamped. Closes #93.

Deploy order: this first, then the crossband side. A 1.4 crossband against this service sees nothing new and keeps working.

## Detail

- `FactBody.guest_speakers: list[str]` (`memory_service/api.py`), max 12 entries; a longer list is a 422 like `web_sources` past 20. `add_fact` passes it through.
- `ledger.add_fact` gains `guest_speakers`. New `_guest_list` normalises it (strip, drop empties, dedupe, keep order) and drops anything `walls.speaker_class` does not read as `guest` or `guest-unknown`. New `_render_guests` names at most five guests, 300 characters, `guest:unknown` as "an unidentified guest". The clause is applied right after the web-derived hold: it takes the reason slot when nothing else held the fact, follows a `web-derived:` reason after `; `, and never touches an `external write` reason.
- `reason_class()` needs no change. `REASON_CLASS_COPY` in `memory_service/static/index.html` gains the heading. `Settings.contract_version` is "1.5".
- `docs/API.md`: title, the 1.5 rule, the health example, the `POST /facts` body and a paragraph on both stamps, and the `reason_class` token list completed (it omitted `web-derived`, `source-trust-judged` and `source-deleted`, which the code already produces).
- Tests: `tests/test_contract_1_5.py` (10), `tests/test_guest_present_hold.py` (8, including the recall-and-summary invariant), two truth-table rows in `tests/test_review_grouping.py`; the 1.4 health pin now checks the version only moves up. 513 pass. `changelog.d/93-contract-1-5.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
